### PR TITLE
Add CI workflow for backend and frontend testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: Sawaka CI
+
+on:
+  push:
+    branches: [ main, qa ]
+  pull_request:
+    branches: [ main, qa ]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    env:
+      NODE_ENV: test
+      MONGO_URI: ${{ secrets.MONGO_URI_TEST }}
+      FRONTEND_URL: http://localhost:3000
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: npm
+
+      # ================= BACKEND =================
+      - name: Install backend dependencies
+        working-directory: backend-api
+        run: npm install
+
+      - name: Run backend tests (Jest)
+        working-directory: backend-api
+        run: npm test
+
+      # ================= API (Newman) =================
+      - name: Install Newman
+        run: npm install -g newman
+
+      - name: Start backend API
+        working-directory: backend-api
+        run: |
+          npm start &
+          sleep 10
+
+      - name: Run API tests (Newman)
+        run: |
+          newman run tests/api/postman/sawaka.postman_collection.json \
+          -e tests/api/postman/sawaka.postman_environment.json
+
+      # ================= FRONTEND =================
+      - name: Install frontend dependencies
+        run: npm install
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: npx playwright test


### PR DESCRIPTION
## 🚀 Objective

Set up a Continuous Integration (CI) pipeline for the Sawaka project to ensure code quality before merging into the `main` branch.

## 🧩 Changes Introduced

- Added a GitHub Actions workflow
- Automatic execution of backend tests (Jest + Supertest)
- Automatic execution of API tests (Postman / Newman)
- Automatic execution of frontend tests (Playwright)
- Enabled `NODE_ENV=test` for an isolated testing environment

## 🧪 Tests Performed

- Backend tests validated locally using Jest
- API tests validated using Newman
- Frontend tests validated using Playwright
- CI automatically triggered upon Pull Request creation

## 📝 Notes

- The workflow runs on `push` and `pull_request` events targeting `main` and `qa`
- Sensitive secrets (MongoDB connection) are managed via GitHub Secrets
