### PR TITLE
Sawaka Docs on GitHub Pages

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,0 +1,78 @@
+name: Publish Documentation to GitHub Pages
+
+on:
+  push:
+    branches: [main, qa]
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install backend dependencies
+        working-directory: backend-api
+        run: npm ci
+
+      - name: Run JSDoc generation
+        working-directory: backend-api
+        run: npm run docs:generate
+
+      - name: Run Swagger UI static generation
+        working-directory: backend-api
+        run: npm run docs:swagger-ui
+
+      - name: Copy files to site directory
+        run: |
+          mkdir -p site
+          cp -r backend-api/docs/jsdoc site/jsdoc
+          cp -r backend-api/docs/api-docs site/api-docs
+
+      - name: Add root index
+        run: |
+          cat > site/index.html << 'EOF'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>Sawaka Documentation</title>
+          </head>
+          <body>
+            <h1>Sawaka Documentation</h1>
+            <ul>
+              <li><a href="/jsdoc/">JSDoc</a> — Code-level API reference</li>
+              <li><a href="/api-docs/">Swagger UI</a> — Interactive API documentation</li>
+            </ul>
+          </body>
+          </html>
+          EOF
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/backend-api/package.json
+++ b/backend-api/package.json
@@ -7,7 +7,8 @@
     "dev": "nodemon index.js",
     "test": "cross-env NODE_ENV=test CI=true jest --runInBand",
     "test:watch": "jest --watch",
-    "docs:generate": "jsdoc -c jsdoc.json"
+    "docs:generate": "jsdoc -c jsdoc.json",
+    "docs:swagger-ui": "node scripts/generate-swagger-ui.js"
   },
   "keywords": [],
   "author": "",

--- a/backend-api/scripts/generate-swagger-ui.js
+++ b/backend-api/scripts/generate-swagger-ui.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+
+/**
+ * Generates a fully static Swagger UI site from swagger.json,
+ * suitable for GitHub Pages.
+ *
+ * Output: backend-api/docs/api-docs/
+ *   - index.html
+ *   - swagger.json
+ *
+ * Usage:
+ *   node scripts/generate-swagger-ui.js [path/to/swagger.json]
+ *
+ * If no input path is given, looks for:
+ *   - docs/swagger/swagger.json
+ *   - swagger.json (in backend-api root)
+ *
+ * If swagger.json is not found, creates a minimal placeholder spec.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.resolve(__dirname, "..");
+const OUTPUT_DIR = path.join(ROOT, "docs", "api-docs");
+const DEFAULT_INPUT_PATHS = [
+  path.join(ROOT, "docs", "swagger", "swagger.json"),
+  path.join(ROOT, "swagger.json"),
+];
+
+const SWAGGER_UI_VERSION = "5.11.0";
+const CDN_BASE = `https://unpkg.com/swagger-ui-dist@${SWAGGER_UI_VERSION}`;
+
+const INDEX_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Sawaka API Documentation</title>
+  <link rel="stylesheet" href="${CDN_BASE}/swagger-ui.css">
+</head>
+<body>
+  <div id="swagger-ui"></div>
+  <script src="${CDN_BASE}/swagger-ui-bundle.js" crossorigin></script>
+  <script src="${CDN_BASE}/swagger-ui-standalone-preset.js" crossorigin></script>
+  <script>
+    window.onload = function() {
+      window.ui = SwaggerUIBundle({
+        url: "./swagger.json",
+        dom_id: "#swagger-ui",
+        presets: [
+          SwaggerUIBundle.presets.apis,
+          SwaggerUIStandalonePreset
+        ],
+        layout: "StandaloneLayout"
+      });
+    };
+  </script>
+</body>
+</html>
+`;
+
+function findSwaggerJson(explicitPath) {
+  if (explicitPath) {
+    const p = path.isAbsolute(explicitPath) ? explicitPath : path.join(ROOT, explicitPath);
+    if (fs.existsSync(p)) return fs.readFileSync(p, "utf8");
+  }
+  for (const p of DEFAULT_INPUT_PATHS) {
+    if (fs.existsSync(p)) return fs.readFileSync(p, "utf8");
+  }
+  return null;
+}
+
+function getPlaceholderSpec() {
+  return JSON.stringify(
+    {
+      openapi: "3.0.0",
+      info: {
+        title: "Sawaka API",
+        version: "1.0.0",
+        description: "Add swagger.json to backend-api/docs/swagger/ or run swagger-jsdoc to generate the full spec."
+      },
+      paths: {}
+    },
+    null,
+    2
+  );
+}
+
+function main() {
+  const explicitPath = process.argv[2];
+  let specStr = findSwaggerJson(explicitPath);
+
+  if (!specStr) {
+    console.warn("⚠ swagger.json not found. Using placeholder spec.");
+    console.warn("  To use a real spec: place swagger.json in backend-api/docs/swagger/");
+    console.warn("  or pass a path: node scripts/generate-swagger-ui.js path/to/swagger.json");
+    specStr = getPlaceholderSpec();
+  }
+
+  try {
+    JSON.parse(specStr);
+  } catch (e) {
+    console.error("❌ Invalid JSON in swagger spec:", e.message);
+    process.exit(1);
+  }
+
+  if (!fs.existsSync(OUTPUT_DIR)) {
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+  }
+
+  fs.writeFileSync(path.join(OUTPUT_DIR, "index.html"), INDEX_HTML, "utf8");
+  fs.writeFileSync(path.join(OUTPUT_DIR, "swagger.json"), specStr, "utf8");
+
+  console.log("✅ Static Swagger UI site generated");
+  console.log(`   Output: ${OUTPUT_DIR}`);
+  console.log(`   Open: ${path.join(OUTPUT_DIR, "index.html")}`);
+}
+
+main();


### PR DESCRIPTION
# 🚀 Pull Request — Sawaka

## 🎯 Objective
Make Sawaka technical documentation publicly accessible by automatically publishing generated documentation (JSDoc and Swagger UI) to GitHub Pages. This PR enables continuous deployment of documentation on merge to qa or main.

## 🔧 Type of Changes
- [X] New feature
- [ ] Bug fix
- [ ] Code improvement / refactoring
- [X] Documentation update

## 📘 What’s included
GitHub Pages enabled via GitHub Actions
Automated documentation build on push to qa and main
JSDoc generated and published
Swagger UI generated as a static site and published
Index page linking all documentation

##  🌐 Public URLs (after merge)
JSDoc → https://bond52.github.io/sawaka/jsdoc
Swagger UI → https://bond52.github.io/sawaka/api-docs
Docs index → https://bond52.github.io/sawaka/

## 🧪 Tests Performed
Documentation generation verified locally
GitHub Actions workflow validates:
JSDoc generation
Swagger UI static build
Pages deployment
CI pipeline runs without regression

## 📎 Notes
Documentation artifacts are generated only in CI (not committed)
backend-api/docs remains in .gitignore
GitHub Pages source is GitHub Actions
Fully aligned with Sawaka Definition of Done (DoD)
