### PR TITLE
fix: generate absolute supplier activation URLs in emails

### DIFF
--- a/backend-api/.env.example
+++ b/backend-api/.env.example
@@ -17,5 +17,8 @@ CLOUDINARY_API_SECRET=your_api_secret
 # HuggingFace API (pour assistant budget IA)
 HF_API_KEY=your_huggingface_api_key
 
-# Frontend URL (pour CORS)
+# Frontend URL (CORS + liens d'activation fournisseur dans les e-mails)
 FRONTEND_URL=http://localhost:3000
+
+# Fallback si FRONTEND_URL est absent (liens d'activation)
+# APP_BASE_URL=https://qa.sawaka.org

--- a/backend-api/services/EmailService.js
+++ b/backend-api/services/EmailService.js
@@ -1,4 +1,5 @@
 const transporter = require("../utils/mailer");
+const { buildSupplierActivationUrl } = require("../utils/supplierActivationUrl");
 
 function escapeHtml(s) {
   return String(s)
@@ -34,12 +35,7 @@ const EmailService = {
         return false;
       }
 
-      const BASE_URL = process.env.APP_BASE_URL || "https://qa.sawaka.org";
-      const base = BASE_URL.trim().replace(/\/$/, "");
-      const origin = /^https?:\/\//i.test(base) ? base : `https://${base}`;
-      const link = `${origin}/supplier/activate?token=${encodeURIComponent(
-        token
-      )}`;
+      const link = buildSupplierActivationUrl(token);
 
       const safeUrl = escapeHtml(link);
 
@@ -91,10 +87,6 @@ const EmailService = {
   </table>
 </body>
 </html>`.trim(),
-
-headers: {
-  "X-Mailin-track": "0"
-}
       };
 
       const maxAttempts = 3;

--- a/backend-api/services/EmailService.js
+++ b/backend-api/services/EmailService.js
@@ -1,12 +1,5 @@
 const transporter = require("../utils/mailer");
 
-function buildActivationUrl(token) {
-  const raw = (process.env.FRONTEND_URL || "").trim().replace(/\/$/, "");
-  if (!raw) return null;
-  const base = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
-  return `${base}/activate?token=${encodeURIComponent(token)}`;
-}
-
 function escapeHtml(s) {
   return String(s)
     .replace(/&/g, "&amp;")
@@ -41,21 +34,23 @@ const EmailService = {
         return false;
       }
 
-      const url = buildActivationUrl(token);
-      if (!url) {
-        console.error(
-          "EmailService.sendMagicLink: FRONTEND_URL is required to build activation link"
-        );
-        return false;
-      }
+      const BASE_URL = process.env.APP_BASE_URL || "https://qa.sawaka.org";
+      const base = BASE_URL.trim().replace(/\/$/, "");
+      const origin = /^https?:\/\//i.test(base) ? base : `https://${base}`;
+      const link = `${origin}/supplier/activate?token=${encodeURIComponent(
+        token
+      )}`;
 
-      const safeUrl = escapeHtml(url);
+      const safeUrl = escapeHtml(link);
 
       const mailOptions = {
         from,
         to,
         subject: "Activate your Sawaka account",
-        text: `Click the following link to activate your account: ${url}`,
+        headers: {
+          "X-Mailin-track": "0",
+        },
+        text: `Click the following link to activate your account: ${link}`,
         html: `
 <!DOCTYPE html>
 <html lang="en">
@@ -81,7 +76,7 @@ const EmailService = {
           </tr>
           <tr>
             <td style="padding:20px 28px 8px 28px;" align="center">
-              <a href="${url}" style="display:inline-block;padding:12px 28px;background-color:#734c2c;color:#ffffff;text-decoration:none;font-size:15px;font-weight:600;border-radius:8px;">Activate account</a>
+              <a href="${link}" style="display:inline-block;padding:12px 28px;background-color:#734c2c;color:#ffffff;text-decoration:none;font-size:15px;font-weight:600;border-radius:8px;">Activate account</a>
             </td>
           </tr>
           <tr>
@@ -96,6 +91,10 @@ const EmailService = {
   </table>
 </body>
 </html>`.trim(),
+
+headers: {
+  "X-Mailin-track": "0"
+}
       };
 
       const maxAttempts = 3;

--- a/backend-api/services/SupplierService.js
+++ b/backend-api/services/SupplierService.js
@@ -2,6 +2,7 @@ const Supplier = require("../models/Supplier");
 const MagicLinkService = require("./MagicLinkService");
 const MagicLinkToken = require("../models/MagicLinkToken");
 const transporter = require("../utils/mailer");
+const { buildSupplierActivationUrl } = require("../utils/supplierActivationUrl");
 
 const VALIDATION_REASON_MESSAGES = {
   TOKEN_MISSING: "Token required",
@@ -11,11 +12,7 @@ const VALIDATION_REASON_MESSAGES = {
 };
 
 async function sendMagicLinkEmail(to, token) {
-  const base = (process.env.FRONTEND_URL || "").replace(/\/$/, "");
-  const path = process.env.SUPPLIER_MAGIC_LINK_PATH || "/supplier/activate";
-  const url = `${base}${path.startsWith("/") ? path : `/${path}`}?token=${encodeURIComponent(
-    token
-  )}`;
+  const url = buildSupplierActivationUrl(token);
 
   const from =
     process.env.MAIL_FROM || process.env.BREVO_SMTP_USER;

--- a/backend-api/tests/unit/EmailService.test.js
+++ b/backend-api/tests/unit/EmailService.test.js
@@ -2,18 +2,13 @@ jest.mock("../../utils/mailer");
 
 const transporter = require("../../utils/mailer");
 const EmailService = require("../../services/EmailService");
-
-function expectedMagicLinkUrl(appBaseUrl, token) {
-  const BASE_URL = appBaseUrl || "https://qa.sawaka.org";
-  const base = String(BASE_URL).trim().replace(/\/$/, "");
-  const origin = /^https?:\/\//i.test(base) ? base : `https://${base}`;
-  return `${origin}/supplier/activate?token=${encodeURIComponent(token)}`;
-}
+const { buildSupplierActivationUrl } = require("../../utils/supplierActivationUrl");
 
 describe("EmailService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     process.env.APP_BASE_URL = "https://app.example.com";
+    delete process.env.FRONTEND_URL;
     process.env.MAIL_FROM = "noreply@example.com";
     delete process.env.BREVO_SMTP_USER;
     delete process.env.BREVO_SMTP_PASSWORD;
@@ -40,7 +35,7 @@ describe("EmailService", () => {
         })
       );
 
-      const url = expectedMagicLinkUrl(process.env.APP_BASE_URL, token);
+      const url = buildSupplierActivationUrl(token);
       expect(url).toMatch(/\/supplier\/activate\?token=/);
       expect(mailOpts.text).toBe(
         `Click the following link to activate your account: ${url}`
@@ -87,7 +82,7 @@ describe("EmailService", () => {
       await EmailService.sendMagicLink("u@example.org", token);
 
       const mailOpts = transporter.sendMail.mock.calls[0][0];
-      const expected = expectedMagicLinkUrl(process.env.APP_BASE_URL, token);
+      const expected = buildSupplierActivationUrl(token);
       expect(expected).toContain("/supplier/activate?token=");
       expect(expected).toContain(encodeURIComponent(token));
       expect(mailOpts.text).toContain(expected);

--- a/backend-api/tests/unit/EmailService.test.js
+++ b/backend-api/tests/unit/EmailService.test.js
@@ -3,16 +3,17 @@ jest.mock("../../utils/mailer");
 const transporter = require("../../utils/mailer");
 const EmailService = require("../../services/EmailService");
 
-function expectedActivationUrl(frontendBase, token) {
-  const raw = String(frontendBase).trim().replace(/\/$/, "");
-  const base = /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
-  return `${base}/activate?token=${encodeURIComponent(token)}`;
+function expectedMagicLinkUrl(appBaseUrl, token) {
+  const BASE_URL = appBaseUrl || "https://qa.sawaka.org";
+  const base = String(BASE_URL).trim().replace(/\/$/, "");
+  const origin = /^https?:\/\//i.test(base) ? base : `https://${base}`;
+  return `${origin}/supplier/activate?token=${encodeURIComponent(token)}`;
 }
 
 describe("EmailService", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    process.env.FRONTEND_URL = "https://app.example.com";
+    process.env.APP_BASE_URL = "https://app.example.com";
     process.env.MAIL_FROM = "noreply@example.com";
     delete process.env.BREVO_SMTP_USER;
     delete process.env.BREVO_SMTP_PASSWORD;
@@ -39,11 +40,8 @@ describe("EmailService", () => {
         })
       );
 
-      const url = expectedActivationUrl(
-        process.env.FRONTEND_URL,
-        token
-      );
-      expect(url).toMatch(/\/activate\?token=/);
+      const url = expectedMagicLinkUrl(process.env.APP_BASE_URL, token);
+      expect(url).toMatch(/\/supplier\/activate\?token=/);
       expect(mailOpts.text).toBe(
         `Click the following link to activate your account: ${url}`
       );
@@ -83,14 +81,14 @@ describe("EmailService", () => {
       );
     });
 
-    it("builds /activate?token= with encodeURIComponent for special characters", async () => {
+    it("builds /supplier/activate?token= with encodeURIComponent for special characters", async () => {
       transporter.sendMail.mockResolvedValue({});
       const token = "a b+c/d?x=1&y=2";
       await EmailService.sendMagicLink("u@example.org", token);
 
       const mailOpts = transporter.sendMail.mock.calls[0][0];
-      const expected = expectedActivationUrl(process.env.FRONTEND_URL, token);
-      expect(expected).toContain("/activate?token=");
+      const expected = expectedMagicLinkUrl(process.env.APP_BASE_URL, token);
+      expect(expected).toContain("/supplier/activate?token=");
       expect(expected).toContain(encodeURIComponent(token));
       expect(mailOpts.text).toContain(expected);
       expect(mailOpts.html).toContain(expected);
@@ -139,14 +137,16 @@ describe("EmailService", () => {
       expect(transporter.sendMail).not.toHaveBeenCalled();
     });
 
-    it("returns false when FRONTEND_URL is missing", async () => {
-      delete process.env.FRONTEND_URL;
+    it("uses default https://qa.sawaka.org when APP_BASE_URL is unset", async () => {
+      delete process.env.APP_BASE_URL;
+      transporter.sendMail.mockResolvedValue({ messageId: "ok" });
       const result = await EmailService.sendMagicLink(
         "user@example.com",
-        "the-token"
+        "tok"
       );
-      expect(result).toBe(false);
-      expect(transporter.sendMail).not.toHaveBeenCalled();
+      expect(result).toBe(true);
+      const mailOpts = transporter.sendMail.mock.calls[0][0];
+      expect(mailOpts.text).toContain("https://qa.sawaka.org/supplier/activate");
     });
 
     it("returns false when sendMail fails after all retries", async () => {

--- a/backend-api/tests/unit/SupplierService.test.js
+++ b/backend-api/tests/unit/SupplierService.test.js
@@ -53,6 +53,12 @@ describe("SupplierService", () => {
       expect(transporter.sendMail).toHaveBeenCalledWith(
         expect.objectContaining({
           to: "s@example.com",
+          text: expect.stringContaining(
+            "https://app.example.com/supplier/activate?token=abc123token"
+          ),
+          html: expect.stringContaining(
+            "https://app.example.com/supplier/activate?token=abc123token"
+          ),
         })
       );
       expect(result).toBe(supplierDoc);

--- a/backend-api/tests/unit/supplierActivationUrl.test.js
+++ b/backend-api/tests/unit/supplierActivationUrl.test.js
@@ -1,0 +1,49 @@
+const {
+  buildSupplierActivationUrl,
+  DEFAULT_ORIGIN,
+} = require("../../utils/supplierActivationUrl");
+
+describe("supplierActivationUrl", () => {
+  const token = "abc+token/value";
+
+  beforeEach(() => {
+    delete process.env.FRONTEND_URL;
+    delete process.env.APP_BASE_URL;
+    delete process.env.SUPPLIER_MAGIC_LINK_PATH;
+  });
+
+  it("builds absolute URL from FRONTEND_URL", () => {
+    process.env.FRONTEND_URL = "http://localhost:3000";
+    expect(buildSupplierActivationUrl(token)).toBe(
+      `http://localhost:3000/supplier/activate?token=${encodeURIComponent(token)}`
+    );
+  });
+
+  it("falls back to APP_BASE_URL when FRONTEND_URL is unset", () => {
+    process.env.APP_BASE_URL = "https://sawaka.com";
+    expect(buildSupplierActivationUrl(token)).toBe(
+      `https://sawaka.com/supplier/activate?token=${encodeURIComponent(token)}`
+    );
+  });
+
+  it("prepends https when origin has no protocol", () => {
+    process.env.FRONTEND_URL = "sawaka.com";
+    expect(buildSupplierActivationUrl(token)).toBe(
+      `https://sawaka.com/supplier/activate?token=${encodeURIComponent(token)}`
+    );
+  });
+
+  it("uses default origin when env vars are unset", () => {
+    expect(buildSupplierActivationUrl(token)).toBe(
+      `${DEFAULT_ORIGIN}/supplier/activate?token=${encodeURIComponent(token)}`
+    );
+  });
+
+  it("respects SUPPLIER_MAGIC_LINK_PATH", () => {
+    process.env.FRONTEND_URL = "https://app.example.com";
+    process.env.SUPPLIER_MAGIC_LINK_PATH = "custom/activate";
+    expect(buildSupplierActivationUrl(token)).toBe(
+      `https://app.example.com/custom/activate?token=${encodeURIComponent(token)}`
+    );
+  });
+});

--- a/backend-api/utils/supplierActivationUrl.js
+++ b/backend-api/utils/supplierActivationUrl.js
@@ -1,0 +1,21 @@
+const DEFAULT_ORIGIN = "https://qa.sawaka.org";
+
+function resolveAppOrigin() {
+  const raw = (
+    process.env.FRONTEND_URL ||
+    process.env.APP_BASE_URL ||
+    DEFAULT_ORIGIN
+  )
+    .trim()
+    .replace(/\/$/, "");
+  return /^https?:\/\//i.test(raw) ? raw : `https://${raw}`;
+}
+
+function buildSupplierActivationUrl(token) {
+  const origin = resolveAppOrigin();
+  const path = process.env.SUPPLIER_MAGIC_LINK_PATH || "/supplier/activate";
+  const pathPart = path.startsWith("/") ? path : `/${path}`;
+  return `${origin}${pathPart}?token=${encodeURIComponent(token)}`;
+}
+
+module.exports = { resolveAppOrigin, buildSupplierActivationUrl, DEFAULT_ORIGIN };


### PR DESCRIPTION
## Objective

Fix supplier invitation emails containing relative activation paths.

## Problem

Activation links in supplier invitation emails were generated as relative paths:

/supplier/activate?token=...

This caused invalid or non-clickable links in email clients.

## Type of Changes

- [ ] New feature
- [x] Bug fix
- [x] Code improvement / refactoring
- [x] Documentation update

## Solution

Implemented a shared `supplierActivationUrl` utility to generate absolute URLs using:

1. `FRONTEND_URL` (priority)
2. `APP_BASE_URL`
3. fallback to `https://qa.sawaka.org`

Also:
- auto-adds `https://` if protocol is missing
- reused by both `SupplierService` and `EmailService`

## Tests Performed

- Unit tests passing (28/28)
- Manual verification of activation links
- Verified localhost and production-compatible URL generation

## Notes

Example generated URL:

https://sawaka.com/supplier/activate?token=...