### PR TITLE
feat: implement supplier activation frontend flow

### DIFF
--- a/app/lib/apiBase.ts
+++ b/app/lib/apiBase.ts
@@ -1,0 +1,16 @@
+const DEFAULT_API_BASE = "https://ecommerce-web-avec-tailwind.onrender.com";
+
+/** Base URL for backend API calls (QA/prod via NEXT_PUBLIC_API_BASE). */
+export function resolveApiBaseUrl(): string {
+  const fromEnv = process.env.NEXT_PUBLIC_API_BASE?.trim();
+  if (fromEnv) return fromEnv.replace(/\/+$/, "");
+
+  if (
+    typeof window !== "undefined" &&
+    window.location.hostname === "localhost"
+  ) {
+    return "http://localhost:5000";
+  }
+
+  return DEFAULT_API_BASE;
+}

--- a/app/lib/apiSuppliers.ts
+++ b/app/lib/apiSuppliers.ts
@@ -1,0 +1,64 @@
+import { resolveApiBaseUrl } from "./apiBase";
+
+export const SUPPLIER_JWT_KEY = "supplierJwt";
+
+export type ActivateSupplierResult =
+  | { ok: true; token: string }
+  | { ok: false; status: number; detail: string };
+
+/**
+ * Activates a supplier account via magic-link token (GET /api/suppliers/magic-link/:token).
+ */
+export async function activateSupplierWithMagicLink(
+  token: string
+): Promise<ActivateSupplierResult> {
+  const apiBase = resolveApiBaseUrl();
+  const url = `${apiBase}/api/suppliers/magic-link/${encodeURIComponent(token)}`;
+
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: "GET",
+      credentials: "include",
+    });
+  } catch (err) {
+    console.error("[apiSuppliers] activateSupplierWithMagicLink: network error", {
+      err,
+      url,
+    });
+    return { ok: false, status: 0, detail: "network_error" };
+  }
+
+  let data: { token?: unknown; error?: unknown; message?: unknown } = {};
+  try {
+    data = await res.json();
+  } catch {
+    /* non-JSON body */
+  }
+
+  if (!res.ok) {
+    const detail =
+      (typeof data.error === "string" && data.error) ||
+      (typeof data.message === "string" && data.message) ||
+      `HTTP ${res.status}`;
+    console.error("[apiSuppliers] activateSupplierWithMagicLink: API error", {
+      status: res.status,
+      detail,
+      url,
+    });
+    return { ok: false, status: res.status, detail };
+  }
+
+  const jwt =
+    typeof data.token === "string" && data.token.length > 0 ? data.token : null;
+
+  if (!jwt) {
+    console.error(
+      "[apiSuppliers] activateSupplierWithMagicLink: missing token in response",
+      { status: res.status, url }
+    );
+    return { ok: false, status: res.status, detail: "missing_jwt" };
+  }
+
+  return { ok: true, token: jwt };
+}


### PR DESCRIPTION
## Objective

Implement the supplier activation page and frontend activation flow.

## Description

Added the `/supplier/activate` frontend route to support supplier invitation links sent by email.

The page:
- reads the `token` query parameter
- calls the backend activation API
- handles loading, success, and error states
- stores the returned supplier JWT in localStorage

## Type of Changes

- [x] New feature
- [ ] Bug fix
- [x] Code improvement / refactoring
- [ ] Documentation update

## Files Added

- `app/supplier/activate/page.tsx`
- `app/lib/apiBase.ts`
- `app/lib/apiSuppliers.ts`

## Tests Performed

- Verified `/supplier/activate` route loads correctly
- Verified token extraction from query string
- Verified backend activation API call
- Verified success and error states
- Verified JWT storage in localStorage
- Verified QA-compatible API resolution

## Notes

This PR completes the supplier invitation flow introduced previously:
- invitation email
- absolute activation URL
- frontend activation page
- backend supplier activation