### PR TITLE
feat(i18n): add language switcher to header

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -61,114 +61,123 @@ export default function Header() {
 
   const closeMobileMenu = () => setShowMobileMenu(false);
 
+  const authActions = user ? (
+    <div className="relative">
+      <button
+        onClick={() => setShowUserMenu(!showUserMenu)}
+        className="flex items-center gap-2 px-2 py-1 rounded-lg hover:bg-gray-100"
+      >
+        <div className="w-8 h-8 bg-sawaka-500 rounded-full flex items-center justify-center text-white">
+          {user.firstName?.charAt(0) || user.username.charAt(0)}
+        </div>
+        <span className="text-sm hidden lg:inline">
+          {user.firstName || user.username}
+        </span>
+      </button>
+
+      {showUserMenu && (
+        <div className="absolute right-0 top-full mt-2 w-56 bg-white border rounded-lg shadow-lg py-2 z-50">
+          <Link href="/profile" className="block px-4 py-2 hover:bg-gray-50">
+            {t("navigation.profile")}
+          </Link>
+          <Link
+            href="/vendeur/articles"
+            className="block px-4 py-2 hover:bg-gray-50"
+          >
+            {t("navigation.myCreations")}
+          </Link>
+          {isAdmin && (
+            <>
+              <hr className="my-2" />
+              <Link
+                href="/admin"
+                className="block px-4 py-2 hover:bg-gray-50 font-semibold text-sawaka-700"
+              >
+                {t("navigation.admin")}
+              </Link>
+            </>
+          )}
+          <hr className="my-2" />
+          <button
+            onClick={handleLogout}
+            className="block w-full text-left px-4 py-2 text-red-600 hover:bg-red-50"
+          >
+            {t("navigation.logout")}
+          </button>
+        </div>
+      )}
+    </div>
+  ) : (
+    <>
+      <button
+        onClick={() => showAuthUnavailable("login")}
+        className="text-sm font-medium hover:underline whitespace-nowrap"
+      >
+        {t("navigation.login")}
+      </button>
+      <button
+        onClick={() => showAuthUnavailable("register")}
+        className="bg-orange-500 hover:bg-orange-600 text-white px-4 py-2 rounded-lg text-sm font-semibold transition whitespace-nowrap"
+      >
+        {t("navigation.register")}
+      </button>
+    </>
+  );
+
   return (
     <>
       <header className="sticky top-0 z-40 bg-white border-b border-gray-200">
-        <div className="wrap h-16 flex items-center justify-between">
+        <div className="wrap h-16 flex items-center gap-3 sm:gap-4">
           <Link
             href="/"
-            className="flex items-center gap-2 font-bold text-lg text-sawaka-700"
+            className="flex shrink-0 items-center gap-2 font-bold text-lg text-sawaka-700"
           >
             <span className="w-9 h-9 rounded-lg bg-orange-500 text-white flex items-center justify-center">
               S
             </span>
-            {t("common.brand")}
+            <span className="hidden sm:inline">{t("common.brand")}</span>
           </Link>
 
-          <nav className="hidden md:flex items-center gap-10 text-sm font-medium text-gray-700">
-            <Link href="/" className="hover:text-sawaka-900">
+          <nav className="hidden lg:flex flex-1 items-center justify-center gap-8 text-sm font-medium text-gray-700 min-w-0">
+            <Link href="/" className="hover:text-sawaka-900 whitespace-nowrap">
               {t("navigation.home")}
             </Link>
-            <Link href="/produits" className="hover:text-sawaka-900">
+            <Link
+              href="/produits"
+              className="hover:text-sawaka-900 whitespace-nowrap"
+            >
               {t("navigation.market")}
             </Link>
-            <Link href="/projets" className="hover:text-sawaka-900">
+            <Link
+              href="/projets"
+              className="hover:text-sawaka-900 whitespace-nowrap"
+            >
               {t("navigation.projects")}
             </Link>
             <button
               onClick={showConcoursUnavailable}
-              className="hover:text-sawaka-900 text-left"
+              className="hover:text-sawaka-900 text-left whitespace-nowrap"
             >
               {t("navigation.contest")}
             </button>
-            <Link href="/reseau" className="hover:text-sawaka-900">
+            <Link
+              href="/reseau"
+              className="hover:text-sawaka-900 whitespace-nowrap"
+            >
               {t("navigation.network")}
             </Link>
           </nav>
 
-          <div className="hidden md:flex items-center gap-4">
+          <div className="hidden lg:flex shrink-0 items-center gap-3 ml-auto">
             <LanguageSwitcher />
-            {user ? (
-              <div className="relative">
-                <button
-                  onClick={() => setShowUserMenu(!showUserMenu)}
-                  className="flex items-center gap-2 px-2 py-1 rounded-lg hover:bg-gray-100"
-                >
-                  <div className="w-8 h-8 bg-sawaka-500 rounded-full flex items-center justify-center text-white">
-                    {user.firstName?.charAt(0) || user.username.charAt(0)}
-                  </div>
-                  <span className="text-sm">
-                    {user.firstName || user.username}
-                  </span>
-                </button>
-
-                {showUserMenu && (
-                  <div className="absolute right-0 top-full mt-2 w-56 bg-white border rounded-lg shadow-lg py-2 z-50">
-                    <Link
-                      href="/profile"
-                      className="block px-4 py-2 hover:bg-gray-50"
-                    >
-                      {t("navigation.profile")}
-                    </Link>
-                    <Link
-                      href="/vendeur/articles"
-                      className="block px-4 py-2 hover:bg-gray-50"
-                    >
-                      {t("navigation.myCreations")}
-                    </Link>
-                    {isAdmin && (
-                      <>
-                        <hr className="my-2" />
-                        <Link
-                          href="/admin"
-                          className="block px-4 py-2 hover:bg-gray-50 font-semibold text-sawaka-700"
-                        >
-                          {t("navigation.admin")}
-                        </Link>
-                      </>
-                    )}
-                    <hr className="my-2" />
-                    <button
-                      onClick={handleLogout}
-                      className="block w-full text-left px-4 py-2 text-red-600 hover:bg-red-50"
-                    >
-                      {t("navigation.logout")}
-                    </button>
-                  </div>
-                )}
-              </div>
-            ) : (
-              <>
-                <button
-                  onClick={() => showAuthUnavailable("login")}
-                  className="text-sm font-medium hover:underline"
-                >
-                  {t("navigation.login")}
-                </button>
-                <button
-                  onClick={() => showAuthUnavailable("register")}
-                  className="bg-orange-500 hover:bg-orange-600 text-white px-4 py-2 rounded-lg text-sm font-semibold transition"
-                >
-                  {t("navigation.register")}
-                </button>
-              </>
-            )}
+            {authActions}
           </div>
 
-          <div className="md:hidden flex items-center gap-3">
+          <div className="flex lg:hidden shrink-0 items-center gap-2 sm:gap-3 ml-auto">
             <LanguageSwitcher />
             <button
-              className="text-2xl"
+              type="button"
+              className="text-2xl leading-none p-1"
               onClick={() => setShowMobileMenu(true)}
               aria-label={t("common.openMenu")}
             >
@@ -195,6 +204,13 @@ export default function Header() {
               >
                 ✕
               </button>
+            </div>
+
+            <div className="pb-4 border-b border-gray-100">
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wide mb-3">
+                {t("language.switcher")}
+              </p>
+              <LanguageSwitcher />
             </div>
 
             <nav className="flex flex-col gap-4 text-base font-medium">

--- a/src/i18n/LanguageSwitcher.tsx
+++ b/src/i18n/LanguageSwitcher.tsx
@@ -8,30 +8,41 @@ const OPTIONS: { value: Locale; label: string }[] = [
   { value: "fr", label: "FR" },
 ];
 
-export default function LanguageSwitcher() {
+type LanguageSwitcherProps = {
+  className?: string;
+};
+
+export default function LanguageSwitcher({ className = "" }: LanguageSwitcherProps) {
   const { locale, setLocale, t } = useTranslation();
 
   return (
     <div
-      className="flex items-center rounded-lg border border-gray-200 overflow-hidden text-xs font-semibold"
+      data-testid="language-switcher"
+      className={`inline-flex items-center rounded-lg border-2 border-orange-200 bg-white p-0.5 shadow-sm ${className}`.trim()}
       role="group"
       aria-label={t("language.switcher")}
     >
-      {OPTIONS.map(({ value, label }) => (
-        <button
-          key={value}
-          type="button"
-          onClick={() => setLocale(value)}
-          className={`px-2.5 py-1.5 transition ${
-            locale === value
-              ? "bg-sawaka-600 text-white"
-              : "bg-white text-gray-600 hover:bg-gray-50"
-          }`}
-          aria-pressed={locale === value}
-        >
-          {label}
-        </button>
-      ))}
+      {OPTIONS.map(({ value, label }) => {
+        const active = locale === value;
+        return (
+          <button
+            key={value}
+            type="button"
+            data-testid={`language-switcher-${value}`}
+            onClick={() => setLocale(value)}
+            className={[
+              "min-w-[2.75rem] rounded-md px-3 py-1.5 text-sm font-bold transition-colors",
+              active
+                ? "bg-orange-500 text-white shadow-sm"
+                : "text-gray-700 hover:bg-orange-50 hover:text-orange-700",
+            ].join(" ")}
+            aria-pressed={active}
+            aria-label={label}
+          >
+            {label}
+          </button>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Objective

Add a visible language switcher to the Sawaka header to allow users to switch between English and French from any page.

## Type of Changes

- [x] New feature
- [ ] Bug fix
- [ ] Code improvement / refactoring
- [ ] Documentation update

## Tests Performed

- Verified EN/FR switcher is visible in the desktop header
- Verified EN/FR switcher is accessible on mobile navigation
- Verified language changes instantly without page reload
- Verified selected language persists after page refresh
- Verified translations update correctly across pages
- Verified application builds successfully

## Notes

### Included

- Added LanguageSwitcher component
- Added EN / FR selector in desktop navigation
- Added EN / FR selector in mobile navigation drawer
- Integrated with existing i18n provider
- Language preference persisted using localStorage
- Added test identifiers for future automated testing

### User Experience

Users can now switch between English and French from anywhere in the application.

Related to the internationalization feature previously merged into QA.