### PR TITLE
feat(i18n): add language switcher and supplier category validation

### DIFF
--- a/app/add-supplier/components/SupplierForm.tsx
+++ b/app/add-supplier/components/SupplierForm.tsx
@@ -229,7 +229,10 @@ export default function SupplierForm() {
   const [submitting, setSubmitting] = useState(false);
   const submitLockRef = useRef(false);
 
-  function validateForm(values: FormState): Record<string, string> {
+  function validateForm(
+    values: FormState,
+    selectedCategories: Category[]
+  ): Record<string, string> {
     const errors: Record<string, string> = {};
     const name = values.name.trim();
     const country = values.country.trim();
@@ -237,11 +240,16 @@ export default function SupplierForm() {
     const phone = values.phone.trim();
     const publicEmail = values.publicEmail.trim();
     const website = values.website.trim();
+    const safeCategories = normalizeCategoryValues(selectedCategories);
 
     if (!name) {
       errors.name = t("suppliers.validation.nameRequired");
     } else if (name.length < 2) {
       errors.name = t("suppliers.validation.nameMin");
+    }
+
+    if (safeCategories.length === 0) {
+      errors.categories = t("suppliers.validation.categoriesRequired");
     }
 
     if (!country) {
@@ -310,7 +318,7 @@ export default function SupplierForm() {
     setServerMessage(null);
     setSuccess(false);
 
-    const errors = validateForm(form);
+    const errors = validateForm(form, categories);
     if (Object.keys(errors).length > 0) {
       setFieldErrors(errors);
       queueMicrotask(() => scrollToFirstFieldError(errors));
@@ -467,12 +475,19 @@ export default function SupplierForm() {
           </div>
 
           <div className="space-y-3">
-            <span className={`${labelClass} mb-0`}>{t("suppliers.categorySingle")}</span>
+            <span className={`${labelClass} mb-0`}>
+              {t("suppliers.categorySingle")}{" "}
+              <span className="text-red-600">*</span>
+            </span>
             <div
               id="supplier-categories"
               className="flex flex-wrap gap-2.5"
               role="group"
               aria-label={t("suppliers.categoriesAria")}
+              aria-invalid={!!fieldErrors.categories}
+              aria-describedby={
+                fieldErrors.categories ? "err-categories" : undefined
+              }
             >
               {SUPPLIER_CATEGORY_OPTIONS.map((opt) => {
                 const selected = categories.includes(opt.value);
@@ -480,6 +495,7 @@ export default function SupplierForm() {
                   <button
                     key={opt.value}
                     type="button"
+                    data-testid={`supplier-category-${opt.value}`}
                     onClick={() => toggleCategory(opt.value)}
                     className={[
                       "rounded-full border px-3.5 py-2 text-xs font-medium transition-all md:text-[13px]",
@@ -494,7 +510,11 @@ export default function SupplierForm() {
               })}
             </div>
             {fieldErrors.categories && (
-              <p className="mt-1.5 text-sm font-medium text-red-600">
+              <p
+                id="err-categories"
+                data-testid="supplier-error-categories"
+                className="mt-1.5 text-sm font-medium text-red-600"
+              >
                 {fieldErrors.categories}
               </p>
             )}

--- a/backend-api/controllers/supplier.controller.js
+++ b/backend-api/controllers/supplier.controller.js
@@ -18,7 +18,11 @@ async function createSupplier(req, res) {
       ) || err.name === "ValidationError";
 
     if (isBadRequest) {
-      return res.status(400).json({ error: msg });
+      const body = { error: msg };
+      if (err.errors && typeof err.errors === "object") {
+        body.errors = err.errors;
+      }
+      return res.status(400).json(body);
     }
 
     console.error("supplier.controller.createSupplier:", err);

--- a/backend-api/services/SupplierService.js
+++ b/backend-api/services/SupplierService.js
@@ -47,6 +47,14 @@ const SupplierService = {
       throw new Error("phone must be at least 6 characters");
     }
 
+    if (!Array.isArray(clean.categories) || clean.categories.length === 0) {
+      const err = new Error("categories is required");
+      err.errors = {
+        categories: "At least one category is required",
+      };
+      throw err;
+    }
+
     let supplier;
     try {
       supplier = await Supplier.create({

--- a/backend-api/tests/unit/SupplierService.test.js
+++ b/backend-api/tests/unit/SupplierService.test.js
@@ -38,6 +38,7 @@ describe("SupplierService", () => {
         accountEmail: "s@example.com",
         phone: "0612345678",
         companyName: "Acme",
+        categories: ["construction_materials"],
       });
 
       expect(Supplier.create).toHaveBeenCalledWith(
@@ -45,6 +46,7 @@ describe("SupplierService", () => {
           accountEmail: "s@example.com",
           phone: "0612345678",
           companyName: "Acme",
+          categories: ["construction_materials"],
           status: "Invited",
           isVisible: false,
         })
@@ -64,9 +66,81 @@ describe("SupplierService", () => {
       expect(result).toBe(supplierDoc);
     });
 
+    it("creates supplier with multiple categories", async () => {
+      const supplierDoc = {
+        _id: supplierId,
+        accountEmail: "s@example.com",
+        phone: "0612345678",
+        categories: ["construction_materials", "wood_lumber"],
+      };
+      Supplier.create.mockResolvedValue(supplierDoc);
+      MagicLinkService.generateToken.mockResolvedValue({
+        _id: tokenDocId,
+        token: "abc123token",
+      });
+      transporter.sendMail.mockResolvedValue({ messageId: "1" });
+
+      const result = await SupplierService.createSupplier({
+        accountEmail: "s@example.com",
+        phone: "0612345678",
+        categories: ["construction_materials", "wood_lumber"],
+      });
+
+      expect(Supplier.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          categories: ["construction_materials", "wood_lumber"],
+        })
+      );
+      expect(result).toBe(supplierDoc);
+    });
+
+    it("throws when categories is missing", async () => {
+      await expect(
+        SupplierService.createSupplier({
+          accountEmail: "s@example.com",
+          phone: "0612345678",
+        })
+      ).rejects.toMatchObject({
+        message: "categories is required",
+        errors: { categories: "At least one category is required" },
+      });
+      expect(Supplier.create).not.toHaveBeenCalled();
+    });
+
+    it("throws when categories is an empty array", async () => {
+      await expect(
+        SupplierService.createSupplier({
+          accountEmail: "s@example.com",
+          phone: "0612345678",
+          categories: [],
+        })
+      ).rejects.toMatchObject({
+        message: "categories is required",
+        errors: { categories: "At least one category is required" },
+      });
+      expect(Supplier.create).not.toHaveBeenCalled();
+    });
+
+    it("throws when categories is null", async () => {
+      await expect(
+        SupplierService.createSupplier({
+          accountEmail: "s@example.com",
+          phone: "0612345678",
+          categories: null,
+        })
+      ).rejects.toMatchObject({
+        message: "categories is required",
+        errors: { categories: "At least one category is required" },
+      });
+      expect(Supplier.create).not.toHaveBeenCalled();
+    });
+
     it("throws when accountEmail is missing", async () => {
       await expect(
-        SupplierService.createSupplier({ phone: "0612345678" })
+        SupplierService.createSupplier({
+          phone: "0612345678",
+          categories: ["construction_materials"],
+        })
       ).rejects.toThrow("accountEmail is required");
       expect(Supplier.create).not.toHaveBeenCalled();
     });
@@ -76,6 +150,7 @@ describe("SupplierService", () => {
         SupplierService.createSupplier({
           accountEmail: "s@example.com",
           phone: "12345",
+          categories: ["construction_materials"],
         })
       ).rejects.toThrow("phone must be at least 6 characters");
       expect(Supplier.create).not.toHaveBeenCalled();
@@ -83,7 +158,10 @@ describe("SupplierService", () => {
 
     it("throws when phone is missing", async () => {
       await expect(
-        SupplierService.createSupplier({ accountEmail: "s@example.com" })
+        SupplierService.createSupplier({
+          accountEmail: "s@example.com",
+          categories: ["construction_materials"],
+        })
       ).rejects.toThrow("phone is required");
       expect(Supplier.create).not.toHaveBeenCalled();
     });
@@ -103,6 +181,7 @@ describe("SupplierService", () => {
         SupplierService.createSupplier({
           accountEmail: "not-an-email",
           phone: "0612345678",
+          categories: ["construction_materials"],
         })
       ).rejects.toThrow("Invalid account email format");
     });
@@ -115,6 +194,7 @@ describe("SupplierService", () => {
         SupplierService.createSupplier({
           accountEmail: "s@example.com",
           phone: "0612345678",
+          categories: ["construction_materials"],
         })
       ).rejects.toThrow("Invalid phone format");
     });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -280,6 +280,7 @@
     "validation": {
       "nameRequired": "Enter the supplier name (required field).",
       "nameMin": "Name must be at least 2 characters.",
+      "categoriesRequired": "Please select at least one category.",
       "countryRequired": "Enter the country (required field).",
       "accountEmailRequired": "Enter the account email (required field).",
       "accountEmailInvalid": "Account email is not valid (e.g. contact@company.com).",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -280,6 +280,7 @@
     "validation": {
       "nameRequired": "Indiquez le nom du fournisseur (champ obligatoire).",
       "nameMin": "Le nom doit contenir au moins 2 caractères.",
+      "categoriesRequired": "Veuillez sélectionner au moins une catégorie.",
       "countryRequired": "Indiquez le pays (champ obligatoire).",
       "accountEmailRequired": "Indiquez l'e-mail du compte (champ obligatoire).",
       "accountEmailInvalid": "L'e-mail du compte n'est pas valide (ex. : contact@entreprise.com).",

--- a/tests/ui/add-supplier.spec.ts
+++ b/tests/ui/add-supplier.spec.ts
@@ -18,12 +18,32 @@ test.describe("/add-supplier", () => {
     await page.getByTestId("supplier-submit").click();
 
     await expect(page.getByTestId("supplier-error-name")).toBeVisible();
+    await expect(page.getByTestId("supplier-error-categories")).toBeVisible();
     await expect(page.getByTestId("supplier-error-country")).toBeVisible();
     await expect(page.getByTestId("supplier-error-account-email")).toBeVisible();
     await expect(page.getByTestId("supplier-error-phone")).toBeVisible();
   });
 
-  test("fill required fields submits and shows success message", async ({
+  test("submit without category blocks submission and shows validation error", async ({
+    page,
+  }) => {
+    await page.getByTestId("supplier-input-name").fill("Playwright Test Supplier");
+    await page.getByTestId("supplier-input-country").fill("Cameroon");
+    await page
+      .getByTestId("supplier-input-account-email")
+      .fill("supplier@test.example");
+    await page.getByTestId("supplier-input-phone").fill("+237612345678");
+
+    await page.getByTestId("supplier-submit").click();
+
+    await expect(page.getByTestId("supplier-error-categories")).toBeVisible();
+    await expect(page.getByTestId("supplier-error-categories")).toHaveText(
+      "Please select at least one category."
+    );
+    await expect(page.getByTestId("supplier-success")).not.toBeVisible();
+  });
+
+  test("fill required fields with one category submits and shows success message", async ({
     page,
   }) => {
     await page.route("**/api/suppliers", async (route) => {
@@ -44,6 +64,36 @@ test.describe("/add-supplier", () => {
       .getByTestId("supplier-input-account-email")
       .fill("supplier@test.example");
     await page.getByTestId("supplier-input-phone").fill("+237612345678");
+    await page.getByTestId("supplier-category-construction_materials").click();
+
+    await page.getByTestId("supplier-submit").click();
+
+    await expect(page.getByTestId("supplier-success")).toBeVisible();
+  });
+
+  test("fill required fields with multiple categories submits and shows success message", async ({
+    page,
+  }) => {
+    await page.route("**/api/suppliers", async (route) => {
+      if (route.request().method() !== "POST") {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true }),
+      });
+    });
+
+    await page.getByTestId("supplier-input-name").fill("Playwright Test Supplier");
+    await page.getByTestId("supplier-input-country").fill("Cameroon");
+    await page
+      .getByTestId("supplier-input-account-email")
+      .fill("supplier@test.example");
+    await page.getByTestId("supplier-input-phone").fill("+237612345678");
+    await page.getByTestId("supplier-category-construction_materials").click();
+    await page.getByTestId("supplier-category-wood_lumber").click();
 
     await page.getByTestId("supplier-submit").click();
 


### PR DESCRIPTION
## Objective

Complete the internationalization rollout and fix supplier creation validation.

## Type of Changes

- [x] New feature
- [x] Bug fix
- [ ] Code improvement / refactoring
- [ ] Documentation update

## Included

### Internationalization

- Added visible EN / FR language switcher
- Desktop and mobile support
- Language persistence
- Integration with existing i18n provider

### Supplier Validation

- Require at least one category before supplier creation
- Frontend validation
- Backend validation
- EN/FR validation messages
- Updated automated tests

## Tests Performed

- Language switching verified
- Language persistence verified
- Supplier creation blocked when no category is selected
- Supplier creation succeeds with one or more categories
- Backend unit tests passing (18/18)

Closes #203