### PR TITLE
feat: add bilingual support and update legal contact email

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Please **do not open a public issue** for security vulnerabilities.
 
 To report a vulnerability, contact:
 
-**security@sawaka.org**
+**contact@sawaka.org**
 
 We aim to respond within **48 hours**.
 

--- a/app/privacy/PrivacyContent.tsx
+++ b/app/privacy/PrivacyContent.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslation } from "@/src/i18n/I18nProvider";
 
-const PRIVACY_EMAIL = "privacy@sawaka.org";
+const CONTACT_EMAIL = "contact@sawaka.org";
 
 export default function PrivacyContent() {
   const { t } = useTranslation();
@@ -164,10 +164,10 @@ export default function PrivacyContent() {
             <p>
               {t("privacy.s10P2Before")}{" "}
               <a
-                href={`mailto:${PRIVACY_EMAIL}`}
+                href={`mailto:${CONTACT_EMAIL}`}
                 className="text-sawaka-700 underline hover:text-sawaka-800"
               >
-                {PRIVACY_EMAIL}
+                {CONTACT_EMAIL}
               </a>
               {t("privacy.s10P2After")}
             </p>
@@ -192,10 +192,10 @@ export default function PrivacyContent() {
             <p>
               {t("privacy.s12P1Before")}{" "}
               <a
-                href={`mailto:${PRIVACY_EMAIL}`}
+                href={`mailto:${CONTACT_EMAIL}`}
                 className="text-sawaka-700 underline hover:text-sawaka-800"
               >
-                {PRIVACY_EMAIL}
+                {CONTACT_EMAIL}
               </a>
               {t("privacy.s12P1After")}
             </p>


### PR DESCRIPTION
## 🎯 Objective

Add bilingual support for the Terms of Use and Privacy Policy pages to align with Sawaka's bilingual user experience.

## 🔧 Type of Changes

- [x] New feature
- [ ] Bug fix
- [ ] Code improvement / refactoring
- [x] Documentation update

## 📋 Changes Included

- Added French translations for the Terms of Use page
- Added French translations for the Privacy Policy page
- Reused the existing Sawaka internationalization mechanism
- Updated `/terms` to display content based on the selected application language
- Updated `/privacy` to display content based on the selected application language
- Replaced placeholder Sawaka contact email addresses with `contact@sawaka.org`
- Preserved page structure, version numbers, and dates in both languages
- Kept existing footer links unchanged
- Maintained responsive behavior on desktop and mobile devices

## 🧪 Tests Performed

- Verified that `/terms` displays English content when the application language is English
- Verified that `/terms` displays French content when the application language is French
- Verified that `/privacy` displays English content when the application language is English
- Verified that `/privacy` displays French content when the application language is French
- Verified that footer links still navigate to `/terms` and `/privacy`
- Verified that `contact@sawaka.org` is used consistently
- Verified page rendering on desktop and mobile layouts

## 📝 Notes

This PR enhances the previously implemented legal pages to support Sawaka's bilingual experience.

Out of scope for this PR:

- Consent management workflows
- Version tracking
- Registration changes
- Backend changes
- Compliance auditing