### PR TITLE
feat: add bilingual mission page

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -36,12 +36,6 @@ export default function Footer() {
           >
             {t("footer.privacy")}
           </Link>
-          <Link
-            href="/publicite"
-            className="!text-white hover:underline hover:!text-white"
-          >
-            {t("footer.advertising")}
-          </Link>
         </div>
       </div>
     </footer>

--- a/app/notre-mission/MissionContent.tsx
+++ b/app/notre-mission/MissionContent.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useTranslation } from "@/src/i18n/I18nProvider";
+
+const CONTACT_EMAIL = "contact@sawaka.org";
+
+const AUDIENCE_KEYS = [
+  "artisans",
+  "makers",
+  "entrepreneurs",
+  "students",
+  "creators",
+  "suppliers",
+  "mentors",
+  "ideas",
+] as const;
+
+const FEATURE_KEYS = [
+  "ideas",
+  "suppliers",
+  "materials",
+  "tools",
+  "experience",
+  "collaborate",
+  "showcase",
+  "network",
+  "learn",
+] as const;
+
+const VALUE_KEYS = [
+  "collaboration",
+  "knowledge",
+  "accessibility",
+  "transparency",
+  "learning",
+  "localImpact",
+  "innovation",
+  "community",
+] as const;
+
+const VISION_KEYS = ["suppliers", "knowledge", "bi", "ai", "mapping"] as const;
+
+const ASSOCIATION_KEYS = [
+  "support",
+  "collaboration",
+  "contributors",
+  "partnerships",
+  "initiatives",
+] as const;
+
+const CTA_KEYS = ["follow", "feedback", "test", "ideas", "community"] as const;
+
+const MISSION_HELP_KEYS = [
+  "discoverIdeas",
+  "findSuppliers",
+  "connectEntrepreneurs",
+  "findResources",
+  "learnCommunity",
+  "collaborate",
+] as const;
+
+const DIFFERENCE_KEYS = [
+  "projectDiscovery",
+  "supplierDiscovery",
+  "collaboration",
+  "communityKnowledge",
+  "practicalGuidance",
+] as const;
+
+const WHY_KEYS = ["noStart", "lackInfo", "noEcosystem"] as const;
+
+function SectionHeading({ children }: { children: ReactNode }) {
+  return (
+    <h2 className="text-xl md:text-2xl font-semibold text-sawaka-800 mb-4">
+      {children}
+    </h2>
+  );
+}
+
+function InfoCard({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="rounded-xl border border-sawaka-200 bg-white p-5 shadow-sm transition-shadow hover:shadow-md">
+      <h3 className="font-semibold text-sawaka-900 mb-2">{title}</h3>
+      <p className="text-sm text-sawaka-700 leading-relaxed">{description}</p>
+    </div>
+  );
+}
+
+function ValueCard({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="rounded-xl border border-sawaka-200 bg-sawaka-50 p-5">
+      <h3 className="font-semibold text-sawaka-900 mb-2">{title}</h3>
+      <p className="text-sm text-sawaka-700 leading-relaxed">{description}</p>
+    </div>
+  );
+}
+
+export default function MissionContent() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="max-w-4xl mx-auto px-6 py-8">
+      <header className="mb-12 rounded-2xl border border-sawaka-200 bg-gradient-to-br from-sawaka-50 to-cream-100 px-6 py-10 sm:px-10">
+        <h1 className="text-3xl md:text-4xl font-bold text-sawaka-900 mb-4">
+          {t("mission.title")}
+        </h1>
+        <p className="text-lg text-sawaka-700 leading-relaxed">
+          {t("mission.subtitle")}
+        </p>
+      </header>
+
+      <div className="space-y-14">
+        <section>
+          <SectionHeading>{t("mission.s1Title")}</SectionHeading>
+          <div className="space-y-4 text-sawaka-700">
+            <p>{t("mission.s1Intro")}</p>
+            <ul className="list-disc pl-6 space-y-2">
+              {WHY_KEYS.map((key) => (
+                <li key={key}>{t(`mission.why.${key}`)}</li>
+              ))}
+            </ul>
+            <p>{t("mission.s1Closing")}</p>
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading>{t("mission.s2Title")}</SectionHeading>
+          <div className="space-y-4 text-sawaka-700">
+            <p>{t("mission.s2Intro")}</p>
+            <ul className="list-disc pl-6 space-y-2">
+              {MISSION_HELP_KEYS.map((key) => (
+                <li key={key}>{t(`mission.help.${key}`)}</li>
+              ))}
+            </ul>
+            <p className="font-medium text-sawaka-800">{t("mission.s2Closing")}</p>
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading>{t("mission.s3Title")}</SectionHeading>
+          <div className="space-y-4 text-sawaka-700">
+            <p>{t("mission.s3Intro")}</p>
+            <ul className="list-disc pl-6 space-y-2">
+              {DIFFERENCE_KEYS.map((key) => (
+                <li key={key}>{t(`mission.difference.${key}`)}</li>
+              ))}
+            </ul>
+            <p>{t("mission.s3Closing")}</p>
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading>{t("mission.s4Title")}</SectionHeading>
+          <p className="text-sawaka-700 mb-6">{t("mission.s4Intro")}</p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {AUDIENCE_KEYS.map((key) => (
+              <InfoCard
+                key={key}
+                title={t(`mission.audience.${key}.title`)}
+                description={t(`mission.audience.${key}.desc`)}
+              />
+            ))}
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading>{t("mission.s5Title")}</SectionHeading>
+          <p className="text-sawaka-700 mb-6">{t("mission.s5Intro")}</p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {FEATURE_KEYS.map((key) => (
+              <InfoCard
+                key={key}
+                title={t(`mission.features.${key}.title`)}
+                description={t(`mission.features.${key}.desc`)}
+              />
+            ))}
+          </div>
+          <p className="mt-6 text-sm text-sawaka-600 italic">
+            {t("mission.s5Closing")}
+          </p>
+        </section>
+
+        <section>
+          <SectionHeading>{t("mission.s6Title")}</SectionHeading>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {VALUE_KEYS.map((key) => (
+              <ValueCard
+                key={key}
+                title={t(`mission.values.${key}.title`)}
+                description={t(`mission.values.${key}.desc`)}
+              />
+            ))}
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading>{t("mission.s7Title")}</SectionHeading>
+          <div className="space-y-4 text-sawaka-700">
+            <p>{t("mission.s7Intro")}</p>
+            <ul className="list-disc pl-6 space-y-2">
+              {VISION_KEYS.map((key) => (
+                <li key={key}>{t(`mission.vision.${key}`)}</li>
+              ))}
+            </ul>
+            <p className="text-sm text-sawaka-600 italic">
+              {t("mission.s7Closing")}
+            </p>
+          </div>
+        </section>
+
+        <section>
+          <SectionHeading>{t("mission.s8Title")}</SectionHeading>
+          <div className="space-y-4 text-sawaka-700">
+            <p>{t("mission.s8Intro")}</p>
+            <ul className="list-disc pl-6 space-y-2">
+              {ASSOCIATION_KEYS.map((key) => (
+                <li key={key}>{t(`mission.association.${key}`)}</li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section className="rounded-2xl border border-sawaka-200 bg-gradient-to-br from-sawaka-50 to-cream-100 px-6 py-8 sm:px-10">
+          <h2 className="text-xl md:text-2xl font-semibold text-sawaka-800 mb-4">
+            {t("mission.ctaTitle")}
+          </h2>
+          <p className="text-sawaka-700 mb-4">{t("mission.ctaIntro")}</p>
+          <ul className="list-disc pl-6 space-y-2 text-sawaka-700 mb-6">
+            {CTA_KEYS.map((key) => (
+              <li key={key}>{t(`mission.cta.${key}`)}</li>
+            ))}
+          </ul>
+          <p className="text-sawaka-700">
+            {t("mission.ctaBefore")}{" "}
+            <a
+              href={`mailto:${CONTACT_EMAIL}`}
+              className="text-sawaka-800 underline hover:text-sawaka-900 font-medium"
+            >
+              {CONTACT_EMAIL}
+            </a>
+            {t("mission.ctaAfter")}
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/notre-mission/page.tsx
+++ b/app/notre-mission/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import MissionContent from "./MissionContent";
+
+export const metadata: Metadata = {
+  title: "Sawaka — About Us & Mission",
+  description:
+    "Discover Sawaka's mission, values, and vision: a collaborative platform connecting entrepreneurs, artisans, makers, suppliers, and communities.",
+};
+
+export default function MissionPage() {
+  return <MissionContent />;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -644,5 +644,180 @@
     "s12Title": "12. Contact",
     "s12P1Before": "Questions regarding this Privacy Policy may be directed to Sawaka through the contact methods made available on the platform or by email at",
     "s12P1After": "."
+  },
+  "mission": {
+    "title": "Our Mission",
+    "subtitle": "Sawaka is more than a marketplace. It is a collaborative platform designed to transform ideas into opportunities by connecting entrepreneurs, artisans, makers, suppliers, and communities.",
+    "s1Title": "Why Sawaka exists",
+    "s1Intro": "Everywhere, motivated people carry project ideas — yet many do not know where to start. They often lack essential elements to move forward:",
+    "why": {
+      "noStart": "practical information to structure and launch a project;",
+      "lackInfo": "contacts, suppliers, and concrete guidance;",
+      "noEcosystem": "access to a local ecosystem where they can find the right people and resources."
+    },
+    "s1Closing": "Many worthwhile projects never materialize because it is hard to find the right environment to move forward. Sawaka was created to bridge that gap.",
+    "s2Title": "Our mission",
+    "s2Intro": "Sawaka helps people who want to create, learn, and build businesses to:",
+    "help": {
+      "discoverIdeas": "discover project ideas suited to their context;",
+      "findSuppliers": "identify suppliers and useful resources;",
+      "connectEntrepreneurs": "connect with experienced entrepreneurs;",
+      "findResources": "find practical information and real-world feedback;",
+      "learnCommunity": "learn within an active community;",
+      "collaborate": "collaborate instead of working in isolation."
+    },
+    "s2Closing": "At the heart of our approach: helping people turn limited resources into concrete, realistic opportunities.",
+    "s3Title": "What makes Sawaka different",
+    "s3Intro": "Unlike traditional marketplaces or professional social networks, Sawaka combines:",
+    "difference": {
+      "projectDiscovery": "project idea exploration;",
+      "supplierDiscovery": "supplier and local resource discovery;",
+      "collaboration": "collaboration tools between members;",
+      "communityKnowledge": "knowledge shared by the community;",
+      "practicalGuidance": "practical guidance to move forward concretely."
+    },
+    "s3Closing": "The platform is designed around concrete collaboration — not networking alone.",
+    "s4Title": "Who Sawaka is for",
+    "s4Intro": "Sawaka brings together complementary profiles within a single local creation ecosystem.",
+    "audience": {
+      "artisans": {
+        "title": "Artisans",
+        "desc": "Showcase your craft, find materials, and connect with other creators in your area."
+      },
+      "makers": {
+        "title": "Makers",
+        "desc": "Access tools, project ideas, and a community to prototype and share your creations."
+      },
+      "entrepreneurs": {
+        "title": "Entrepreneurs",
+        "desc": "Structure your initiatives, find partners, and benefit from the experience of other project leaders."
+      },
+      "students": {
+        "title": "Students",
+        "desc": "Explore concrete ideas, learn from practitioners, and discover resources available around you."
+      },
+      "creators": {
+        "title": "Creators",
+        "desc": "Bring your ideas to life by finding inspiration, feedback, and collaborations within an engaged network."
+      },
+      "suppliers": {
+        "title": "Suppliers",
+        "desc": "Gain visibility among creators and entrepreneurs looking for your products, materials, or services."
+      },
+      "mentors": {
+        "title": "Mentors",
+        "desc": "Share your experience and help others structure or launch their projects."
+      },
+      "ideas": {
+        "title": "People with project ideas",
+        "desc": "Have an idea but don't know where to start? Discover concrete paths and people who can guide you."
+      }
+    },
+    "s5Title": "What you can do on Sawaka",
+    "s5Intro": "The platform offers tools to move from inspiration to action:",
+    "features": {
+      "ideas": {
+        "title": "Explore project ideas",
+        "desc": "Discover entrepreneurial or creative paths suited to your context and means."
+      },
+      "suppliers": {
+        "title": "Discover suppliers",
+        "desc": "Find artisans, retailers, and organizations able to meet your needs."
+      },
+      "materials": {
+        "title": "Find raw materials",
+        "desc": "Locate essential materials for your creations and prototypes."
+      },
+      "tools": {
+        "title": "Locate tools",
+        "desc": "Identify tools available for purchase, rental, or within your community."
+      },
+      "experience": {
+        "title": "Share experience",
+        "desc": "Contribute to collective knowledge by sharing what you have learned in the field."
+      },
+      "collaborate": {
+        "title": "Collaborate on projects",
+        "desc": "Join ongoing initiatives or find people to move forward together."
+      },
+      "showcase": {
+        "title": "Present your work",
+        "desc": "Showcase your achievements and draw attention from the community."
+      },
+      "network": {
+        "title": "Build your professional network",
+        "desc": "Connect with peers, mentors, and local partners."
+      },
+      "learn": {
+        "title": "Learn from other entrepreneurs",
+        "desc": "Benefit from practical advice and real-world experience."
+      }
+    },
+    "s5Closing": "New capabilities will continue to be added progressively, based on community needs.",
+    "s6Title": "Our values",
+    "values": {
+      "collaboration": {
+        "title": "Collaboration",
+        "desc": "We prioritize mutual support and complementarity over isolated competition."
+      },
+      "knowledge": {
+        "title": "Knowledge sharing",
+        "desc": "Each person's experience enriches the whole and accelerates collective learning."
+      },
+      "accessibility": {
+        "title": "Accessibility",
+        "desc": "Sawaka is designed to be simple, inclusive, and usable without complex infrastructure."
+      },
+      "transparency": {
+        "title": "Transparency",
+        "desc": "We communicate openly about our goals, limitations, and progress."
+      },
+      "learning": {
+        "title": "Continuous learning",
+        "desc": "The platform evolves with its users by testing, listening, and improving."
+      },
+      "localImpact": {
+        "title": "Local impact",
+        "desc": "We support initiatives that create value for nearby communities."
+      },
+      "innovation": {
+        "title": "Innovation",
+        "desc": "We explore new ways to connect ideas, skills, and local resources."
+      },
+      "community": {
+        "title": "Community",
+        "desc": "Sawaka is built with and for people who want to create together."
+      }
+    },
+    "s7Title": "Our long-term vision",
+    "s7Intro": "Over time, Sawaka aims to become a trusted ecosystem helping local communities create sustainable economic opportunities. We are exploring directions such as:",
+    "vision": {
+      "suppliers": "richer, better-structured supplier information;",
+      "knowledge": "organized, community-driven knowledge accessible to all;",
+      "bi": "business intelligence tools to better understand local trends and needs;",
+      "ai": "AI-assisted project exploration grounded in relevant local data;",
+      "mapping": "mapping of creation ecosystems at a territorial scale."
+    },
+    "s7Closing": "These directions represent long-term ambitions — they are not commitments to specific products.",
+    "s8Title": "About the association",
+    "s8Intro": "Sawaka is supported by a Canadian non-profit association. Its role is to:",
+    "association": {
+      "support": "support the project's development in the public interest;",
+      "collaboration": "encourage collaboration among community members;",
+      "contributors": "welcome contributors and volunteers;",
+      "partnerships": "develop partnerships with local stakeholders;",
+      "initiatives": "promote community initiatives related to creation and entrepreneurship."
+    },
+    "ctaTitle": "Join the journey",
+    "ctaIntro": "Sawaka is still being built. You can:",
+    "cta": {
+      "follow": "follow the project's progress;",
+      "feedback": "share your feedback and suggestions;",
+      "test": "test new features;",
+      "ideas": "contribute ideas;",
+      "community": "join the community."
+    },
+    "ctaBefore": "For any questions or to get in touch, contact us at",
+    "ctaAfter": "."
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -644,5 +644,180 @@
     "s12Title": "12. Contact",
     "s12P1Before": "Les questions concernant cette Politique de confidentialité peuvent être adressées à Sawaka par les moyens de contact mis à disposition sur la plateforme ou par courriel à",
     "s12P1After": "."
+  },
+  "mission": {
+    "title": "Notre mission",
+    "subtitle": "Sawaka est bien plus qu'une place de marché. C'est une plateforme collaborative conçue pour transformer les idées en opportunités en connectant entrepreneurs, artisans, makers, fournisseurs et communautés.",
+    "s1Title": "Pourquoi Sawaka existe",
+    "s1Intro": "Partout, des personnes motivées portent des idées de projets — mais beaucoup ne savent pas par où commencer. Elles manquent souvent d'éléments essentiels pour avancer :",
+    "why": {
+      "noStart": "des informations pratiques pour structurer et lancer un projet ;",
+      "lackInfo": "de contacts, de fournisseurs et d'orientations concrètes ;",
+      "noEcosystem": "d'accès à un écosystème local où trouver les bonnes personnes et les bonnes ressources."
+    },
+    "s1Closing": "De nombreux projets pertinents n'aboutissent jamais parce qu'il est difficile de trouver le bon environnement pour avancer. Sawaka est né pour combler cet écart.",
+    "s2Title": "Notre mission",
+    "s2Intro": "Sawaka aide les personnes qui veulent créer, apprendre et entreprendre à :",
+    "help": {
+      "discoverIdeas": "découvrir des idées de projets adaptées à leur contexte ;",
+      "findSuppliers": "identifier des fournisseurs et des ressources utiles ;",
+      "connectEntrepreneurs": "entrer en contact avec des entrepreneurs expérimentés ;",
+      "findResources": "trouver des informations pratiques et des retours d'expérience ;",
+      "learnCommunity": "apprendre au sein d'une communauté active ;",
+      "collaborate": "collaborer plutôt que d'avancer en isolement."
+    },
+    "s2Closing": "Au cœur de notre approche : aider chacun à transformer des ressources limitées en opportunités concrètes et réalistes.",
+    "s3Title": "Ce qui rend Sawaka différent",
+    "s3Intro": "Contrairement aux places de marché classiques ou aux réseaux sociaux professionnels, Sawaka combine :",
+    "difference": {
+      "projectDiscovery": "l'exploration d'idées de projets ;",
+      "supplierDiscovery": "la découverte de fournisseurs et de ressources locales ;",
+      "collaboration": "des outils de collaboration entre membres ;",
+      "communityKnowledge": "un savoir partagé par la communauté ;",
+      "practicalGuidance": "des orientations pratiques pour avancer concrètement."
+    },
+    "s3Closing": "La plateforme est conçue autour de la collaboration concrète — pas seulement du réseautage.",
+    "s4Title": "Pour qui est Sawaka",
+    "s4Intro": "Sawaka rassemble des profils complémentaires au sein d'un même écosystème de création locale.",
+    "audience": {
+      "artisans": {
+        "title": "Artisans",
+        "desc": "Mettez en valeur votre savoir-faire, trouvez des matériaux et connectez-vous avec d'autres créateurs de votre région."
+      },
+      "makers": {
+        "title": "Makers",
+        "desc": "Accédez à des outils, des idées de projets et une communauté pour prototyper et partager vos créations."
+      },
+      "entrepreneurs": {
+        "title": "Entrepreneurs",
+        "desc": "Structurez vos initiatives, trouvez des partenaires et bénéficiez de l'expérience d'autres porteurs de projets."
+      },
+      "students": {
+        "title": "Étudiants",
+        "desc": "Explorez des idées concrètes, apprenez des praticiens et découvrez les ressources disponibles autour de vous."
+      },
+      "creators": {
+        "title": "Créateurs",
+        "desc": "Donnez vie à vos idées en trouvant inspiration, retours et collaborations au sein d'un réseau engagé."
+      },
+      "suppliers": {
+        "title": "Fournisseurs",
+        "desc": "Gagnez en visibilité auprès de créateurs et d'entrepreneurs qui recherchent vos produits, matériaux ou services."
+      },
+      "mentors": {
+        "title": "Mentors",
+        "desc": "Partagez votre expérience et aidez d'autres personnes à structurer ou lancer leurs projets."
+      },
+      "ideas": {
+        "title": "Porteurs d'idées",
+        "desc": "Vous avez une idée mais ne savez pas par où commencer ? Découvrez des pistes concrètes et des personnes qui peuvent vous guider."
+      }
+    },
+    "s5Title": "Ce que vous pouvez faire sur Sawaka",
+    "s5Intro": "La plateforme offre des outils pour passer de l'inspiration à l'action :",
+    "features": {
+      "ideas": {
+        "title": "Explorer des idées de projets",
+        "desc": "Découvrez des pistes entrepreneuriales ou créatives adaptées à votre contexte et à vos moyens."
+      },
+      "suppliers": {
+        "title": "Découvrir des fournisseurs",
+        "desc": "Trouvez des artisans, revendeurs et structures capables de répondre à vos besoins."
+      },
+      "materials": {
+        "title": "Trouver des matières premières",
+        "desc": "Localisez les matériaux essentiels pour vos créations et vos prototypes."
+      },
+      "tools": {
+        "title": "Repérer des outils",
+        "desc": "Identifiez les outils disponibles à l'achat, à la location ou au sein de votre communauté."
+      },
+      "experience": {
+        "title": "Partager son expérience",
+        "desc": "Contribuez au savoir collectif en partageant ce que vous avez appris sur le terrain."
+      },
+      "collaborate": {
+        "title": "Collaborer sur des projets",
+        "desc": "Rejoignez des initiatives en cours ou trouvez des personnes pour avancer ensemble."
+      },
+      "showcase": {
+        "title": "Présenter son travail",
+        "desc": "Mettez en avant vos réalisations et attirez l'attention de la communauté."
+      },
+      "network": {
+        "title": "Développer son réseau professionnel",
+        "desc": "Connectez-vous avec des pairs, des mentors et des partenaires locaux."
+      },
+      "learn": {
+        "title": "Apprendre des autres entrepreneurs",
+        "desc": "Bénéficiez de conseils pratiques et de retours d'expérience concrets."
+      }
+    },
+    "s5Closing": "De nouvelles fonctionnalités seront ajoutées progressivement, en fonction des besoins de la communauté.",
+    "s6Title": "Nos valeurs",
+    "values": {
+      "collaboration": {
+        "title": "Collaboration",
+        "desc": "Nous privilégions l'entraide et la complémentarité plutôt que la compétition isolée."
+      },
+      "knowledge": {
+        "title": "Partage des connaissances",
+        "desc": "L'expérience de chacun enrichit l'ensemble et accélère les apprentissages collectifs."
+      },
+      "accessibility": {
+        "title": "Accessibilité",
+        "desc": "Sawaka est pensé pour être simple, inclusif et utilisable sans infrastructure complexe."
+      },
+      "transparency": {
+        "title": "Transparence",
+        "desc": "Nous communiquons ouvertement sur nos objectifs, nos limites et notre progression."
+      },
+      "learning": {
+        "title": "Apprentissage continu",
+        "desc": "La plateforme évolue avec ses utilisateurs, en testant, en écoutant et en s'améliorant."
+      },
+      "localImpact": {
+        "title": "Impact local",
+        "desc": "Nous favorisons les initiatives qui créent de la valeur pour les communautés de proximité."
+      },
+      "innovation": {
+        "title": "Innovation",
+        "desc": "Nous explorons de nouvelles façons de connecter idées, compétences et ressources locales."
+      },
+      "community": {
+        "title": "Communauté",
+        "desc": "Sawaka est construit avec et pour les personnes qui veulent créer ensemble."
+      }
+    },
+    "s7Title": "Notre vision à long terme",
+    "s7Intro": "À long terme, Sawaka vise à devenir un écosystème de confiance qui aide les communautés locales à créer des opportunités économiques durables. Nous explorons notamment :",
+    "vision": {
+      "suppliers": "un annuaire de fournisseurs plus riche et mieux structuré ;",
+      "knowledge": "un savoir communautaire organisé et accessible à tous ;",
+      "bi": "des outils d'intelligence économique pour mieux comprendre les tendances et les besoins locaux ;",
+      "ai": "une exploration de projets assistée par l'IA, fondée sur des données locales pertinentes ;",
+      "mapping": "une cartographie des écosystèmes de création à l'échelle territoriale."
+    },
+    "s7Closing": "Ces orientations constituent des ambitions à long terme — elles ne représentent pas des engagements sur des produits précis.",
+    "s8Title": "L'association",
+    "s8Intro": "Sawaka est soutenu par une association à but non lucratif basée au Canada. Son rôle est de :",
+    "association": {
+      "support": "soutenir le développement du projet dans l'intérêt collectif ;",
+      "collaboration": "encourager la collaboration entre les membres de la communauté ;",
+      "contributors": "accueillir les contributeurs et les bénévoles ;",
+      "partnerships": "développer des partenariats avec des acteurs locaux ;",
+      "initiatives": "promouvoir des initiatives communautaires liées à la création et à l'entrepreneuriat."
+    },
+    "ctaTitle": "Rejoignez l'aventure",
+    "ctaIntro": "Sawaka est encore en construction. Vous pouvez :",
+    "cta": {
+      "follow": "suivre l'évolution du projet ;",
+      "feedback": "partager vos retours et suggestions ;",
+      "test": "tester les nouvelles fonctionnalités ;",
+      "ideas": "proposer des idées ;",
+      "community": "rejoindre la communauté."
+    },
+    "ctaBefore": "Pour toute question ou pour nous écrire, contactez-nous à",
+    "ctaAfter": "."
   }
 }


### PR DESCRIPTION
## 🎯 Objective

Implement a bilingual public Mission page for Sawaka and improve the public footer navigation.

## 🔧 Type of Changes

- [x] New feature
- [ ] Bug fix
- [ ] Code improvement / refactoring
- [x] Documentation update

## 🧪 Tests Performed

- Verified the Mission page is publicly accessible.
- Verified the page displays correctly in both French and English.
- Verified the existing language switcher updates the page content.
- Verified responsive rendering on desktop and mobile.
- Verified the footer "Mission" link correctly navigates to the page.
- Verified the Advertising/Publicité footer link is hidden.
- Verified existing Terms of Use and Privacy Policy pages continue to work.

## 📝 Notes

This pull request introduces the first public Mission page for Sawaka based on the project's Vision Document.

The page explains:
- why Sawaka exists;
- its mission and long-term vision;
- its target users;
- its values;
- the role of the non-profit association supporting the project.

The content is available in both French and English and follows the existing public page design.

No backend changes were made.
