### PR TITLE
docs: remove Canada reference from mission page

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -800,7 +800,7 @@
     },
     "s7Closing": "These directions represent long-term ambitions — they are not commitments to specific products.",
     "s8Title": "About the association",
-    "s8Intro": "Sawaka is supported by a Canadian non-profit association. Its role is to:",
+    "s8Intro": "Sawaka is supported by a non-profit association. Its role is to:",
     "association": {
       "support": "support the project's development in the public interest;",
       "collaboration": "encourage collaboration among community members;",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -800,7 +800,7 @@
     },
     "s7Closing": "Ces orientations constituent des ambitions à long terme — elles ne représentent pas des engagements sur des produits précis.",
     "s8Title": "L'association",
-    "s8Intro": "Sawaka est soutenu par une association à but non lucratif basée au Canada. Son rôle est de :",
+    "s8Intro": "Sawaka est soutenu par une association à but non lucratif. Son rôle est de :",
     "association": {
       "support": "soutenir le développement du projet dans l'intérêt collectif ;",
       "collaboration": "encourager la collaboration entre les membres de la communauté ;",


### PR DESCRIPTION
## 🎯 Objective

Update the Mission page wording to keep Sawaka’s vision broader and less tied to a specific country.

## 🔧 Type of Changes

- [ ] New feature
- [ ] Bug fix
- [ ] Code improvement / refactoring
- [x] Documentation update

## 🧪 Tests Performed

- Verified the Mission page still displays correctly.
- Verified the French text no longer mentions Canada.
- Verified the English text no longer mentions Canada.
- Verified the association section remains clear and readable.

## 📝 Notes

This PR updates the Mission page content by replacing the country-specific association wording with a broader reference to a non-profit association.

No backend changes were made.