### PR TITLE
fix(home): improve hero text contrast

### DIFF
--- a/app/components/home/HeroSection.tsx
+++ b/app/components/home/HeroSection.tsx
@@ -7,19 +7,19 @@ export default function HeroSection() {
   const { t } = useTranslation();
 
   return (
-    <section className="relative h-[70vh] w-full overflow-hidden">
+    <section className="relative h-[70vh] w-full overflow-hidden text-white [&_h1]:!text-white [&_p]:!text-white">
       <img
         src="/images/hero-artisan.png"
         alt={t("home.heroAlt")}
-        className="absolute inset-0 w-full h-full object-cover"
+        className="absolute inset-0 h-full w-full object-cover"
       />
-      <div className="absolute inset-0 bg-black/50" />
-      <div className="relative z-10 h-full flex items-center">
-        <div className="wrap text-white max-w-2xl ml-0 md:ml-12 lg:ml-20">
-          <h1 className="text-4xl md:text-6xl font-bold mb-4">
+      <div className="absolute inset-0 bg-black/55" aria-hidden />
+      <div className="relative z-10 flex h-full items-center">
+        <div className="wrap ml-0 max-w-2xl md:ml-12 lg:ml-20">
+          <h1 className="mb-4 font-display text-4xl font-bold md:text-6xl">
             {t("home.heroTitle")}
           </h1>
-          <p className="text-lg md:text-xl text-white/90 mb-6">
+          <p className="mb-6 text-lg opacity-90 md:text-xl">
             {t("home.heroSubtitle")}
           </p>
           <Link


### PR DESCRIPTION
# 🚀 Pull Request — Sawaka

## 🎯 Objective
Improve the homepage hero text readability after the Sawaka design system update.

The hero is displayed over a dark background image, and the title was inheriting the global brown foreground color, resulting in insufficient contrast.

This change explicitly applies white text styling to the hero content for better readability.

## 🔧 Type of Changes
- [ ] New feature
- [x] Bug fix
- [ ] Code improvement / refactoring
- [ ] Documentation update

## 🧪 Tests Performed
- Verified homepage hero rendering
- Verified hero title and subtitle readability over the background image
- Existing homepage structure and responsive behavior preserved

## 📝 Notes
This is a follow-up fix to the Sawaka UI design system changes.

No business logic, routes, supplier functionality, or application data were modified.