### PR TITLE
fix(auth): allow subsequent magic link requests

### DIFF
--- a/backend-api/index.js
+++ b/backend-api/index.js
@@ -168,7 +168,11 @@ async function connectMongo() {
   if (!process.env.MONGO_URI) return;
 
   await mongoose.connect(process.env.MONGO_URI);
-  await ensureMagicLinkTokenIndexCompatibility();
+  const migratedMagicLinkTokenIndex =
+    await ensureMagicLinkTokenIndexCompatibility();
+  if (migratedMagicLinkTokenIndex) {
+    console.log("✅ MagicLinkToken token_1 index migrated to sparse unique");
+  }
 
   if (!isTestOrCI) console.log("✅ Connecté à MongoDB");
 }

--- a/backend-api/index.js
+++ b/backend-api/index.js
@@ -3,6 +3,9 @@ const cookieParser = require("cookie-parser");
 const cors = require("cors");
 const mongoose = require("mongoose");
 const dotenv = require("dotenv");
+const {
+  ensureMagicLinkTokenIndexCompatibility,
+} = require("./services/MagicLinkTokenIndexService");
 
 dotenv.config();
 const app = express();
@@ -165,6 +168,7 @@ async function connectMongo() {
   if (!process.env.MONGO_URI) return;
 
   await mongoose.connect(process.env.MONGO_URI);
+  await ensureMagicLinkTokenIndexCompatibility();
 
   if (!isTestOrCI) console.log("✅ Connecté à MongoDB");
 }

--- a/backend-api/services/MagicLinkTokenIndexService.js
+++ b/backend-api/services/MagicLinkTokenIndexService.js
@@ -13,7 +13,17 @@ const MagicLinkToken = require("../models/MagicLinkToken");
  */
 async function ensureMagicLinkTokenIndexCompatibility() {
   const collection = MagicLinkToken.collection;
-  const indexes = await collection.indexes();
+  let indexes;
+  try {
+    indexes = await collection.indexes();
+  } catch (err) {
+    // A fresh database has no collection yet. Mongoose creates its declared
+    // sparse indexes when the collection is first used.
+    if (err && (err.code === 26 || err.codeName === "NamespaceNotFound")) {
+      return false;
+    }
+    throw err;
+  }
   const tokenIndex = indexes.find(
     (index) =>
       index &&

--- a/backend-api/services/MagicLinkTokenIndexService.js
+++ b/backend-api/services/MagicLinkTokenIndexService.js
@@ -1,0 +1,42 @@
+const MagicLinkToken = require("../models/MagicLinkToken");
+
+/**
+ * Migrates the legacy non-sparse unique `token_1` index in place.
+ *
+ * Before token hashing was introduced, every token persisted a plaintext
+ * `token` value. Hashed tokens deliberately omit that field. A legacy
+ * non-sparse unique index therefore accepts one omitted value and rejects all
+ * later tokens with a duplicate-key error. Keeping the index sparse preserves
+ * uniqueness for legacy plaintext tokens while allowing hashed-only tokens.
+ *
+ * @returns {Promise<boolean>} Whether a legacy index was migrated.
+ */
+async function ensureMagicLinkTokenIndexCompatibility() {
+  const collection = MagicLinkToken.collection;
+  const indexes = await collection.indexes();
+  const tokenIndex = indexes.find(
+    (index) =>
+      index &&
+      index.name === "token_1" &&
+      index.key &&
+      index.key.token === 1
+  );
+
+  if (!tokenIndex || tokenIndex.sparse) {
+    return false;
+  }
+
+  await collection.dropIndex(tokenIndex.name);
+  await collection.createIndex(
+    { token: 1 },
+    {
+      name: tokenIndex.name,
+      unique: true,
+      sparse: true,
+    }
+  );
+
+  return true;
+}
+
+module.exports = { ensureMagicLinkTokenIndexCompatibility };

--- a/backend-api/tests/integration/supplierManagementAccess.test.js
+++ b/backend-api/tests/integration/supplierManagementAccess.test.js
@@ -63,6 +63,46 @@ describe("POST /api/suppliers/:id/management-link", () => {
     expect(tokens[0].token).toBeFalsy();
   });
 
+  it("generates independent links for repeated requests across suppliers", async () => {
+    const supplierA = await Supplier.create({
+      ...baseSupplier,
+      accountEmail: "supplier-a@example.com",
+      status: "Active",
+      isVisible: true,
+    });
+    const supplierB = await Supplier.create({
+      ...baseSupplier,
+      accountEmail: "supplier-b@example.com",
+      status: "Active",
+      isVisible: true,
+    });
+
+    for (const [supplier, email] of [
+      [supplierA, "supplier-a@example.com"],
+      [supplierB, "supplier-b@example.com"],
+      [supplierA, "supplier-a@example.com"],
+    ]) {
+      const res = await request(app)
+        .post(`/api/suppliers/${supplier._id}/management-link`)
+        .send({ email });
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual({ success: true });
+    }
+
+    const tokens = await MagicLinkToken.find({
+      purpose: "SUPPLIER_MANAGEMENT",
+    }).sort({ createdAt: 1 });
+
+    expect(tokens).toHaveLength(3);
+    expect(tokens.map((token) => token.supplierId.toString())).toEqual([
+      supplierA._id.toString(),
+      supplierB._id.toString(),
+      supplierA._id.toString(),
+    ]);
+    expect(new Set(tokens.map((token) => token.tokenHash)).size).toBe(3);
+    expect(EmailService.sendSupplierManagementEmail).toHaveBeenCalledTimes(3);
+  });
+
   it("returns the same confirmation without sending when email does not match", async () => {
     const supplier = await Supplier.create({
       ...baseSupplier,

--- a/backend-api/tests/integration/supplierManagementAccess.test.js
+++ b/backend-api/tests/integration/supplierManagementAccess.test.js
@@ -5,6 +5,9 @@ const Supplier = require("../../models/Supplier");
 const MagicLinkToken = require("../../models/MagicLinkToken");
 const EmailService = require("../../services/EmailService");
 const supplierRoutes = require("../../routes/supplier.routes");
+const {
+  ensureMagicLinkTokenIndexCompatibility,
+} = require("../../services/MagicLinkTokenIndexService");
 
 jest.mock("../../services/EmailService", () => ({
   sendSupplierActivationEmail: jest.fn(),
@@ -100,6 +103,85 @@ describe("POST /api/suppliers/:id/management-link", () => {
       supplierA._id.toString(),
     ]);
     expect(new Set(tokens.map((token) => token.tokenHash)).size).toBe(3);
+    expect(EmailService.sendSupplierManagementEmail).toHaveBeenCalledTimes(3);
+  });
+
+  it("repairs the legacy token index before persisting sequential A-B-A links", async () => {
+    await MagicLinkToken.collection.insertOne({ migrationFixture: true });
+    await MagicLinkToken.collection.deleteOne({ migrationFixture: true });
+    const existing = await MagicLinkToken.collection.indexes();
+    const existingTokenIndex = existing.find(
+      (index) => index.name === "token_1" && index.key.token === 1
+    );
+    if (existingTokenIndex) {
+      await MagicLinkToken.collection.dropIndex(existingTokenIndex.name);
+    }
+    await MagicLinkToken.collection.createIndex(
+      { token: 1 },
+      { name: "token_1", unique: true }
+    );
+
+    const before = await MagicLinkToken.collection.indexes();
+    const legacyTokenIndex = before.find((index) => index.name === "token_1");
+    expect(legacyTokenIndex).toMatchObject({
+      key: { token: 1 },
+      unique: true,
+    });
+    expect(legacyTokenIndex.sparse).not.toBe(true);
+
+    const supplierA = await Supplier.create({
+      ...baseSupplier,
+      accountEmail: "legacy-a@example.com",
+      status: "Active",
+      isVisible: true,
+    });
+    const supplierB = await Supplier.create({
+      ...baseSupplier,
+      accountEmail: "legacy-b@example.com",
+      status: "Active",
+      isVisible: true,
+    });
+
+    const first = await request(app)
+      .post(`/api/suppliers/${supplierA._id}/management-link`)
+      .send({ email: "legacy-a@example.com" });
+    expect(first.statusCode).toBe(200);
+    expect(EmailService.sendSupplierManagementEmail).toHaveBeenCalledTimes(1);
+
+    const second = await request(app)
+      .post(`/api/suppliers/${supplierB._id}/management-link`)
+      .send({ email: "legacy-b@example.com" });
+    expect(second.statusCode).toBe(200);
+    expect(EmailService.sendSupplierManagementEmail).toHaveBeenCalledTimes(1);
+    expect(
+      await MagicLinkToken.countDocuments({
+        purpose: "SUPPLIER_MANAGEMENT",
+      })
+    ).toBe(1);
+
+    await expect(ensureMagicLinkTokenIndexCompatibility()).resolves.toBe(true);
+    const after = await MagicLinkToken.collection.indexes();
+    expect(after.find((index) => index.name === "token_1")).toMatchObject({
+      key: { token: 1 },
+      unique: true,
+      sparse: true,
+    });
+
+    for (const [supplier, email] of [
+      [supplierB, "legacy-b@example.com"],
+      [supplierA, "legacy-a@example.com"],
+    ]) {
+      const res = await request(app)
+        .post(`/api/suppliers/${supplier._id}/management-link`)
+        .send({ email });
+      expect(res.statusCode).toBe(200);
+    }
+
+    const tokens = await MagicLinkToken.find({
+      purpose: "SUPPLIER_MANAGEMENT",
+    }).sort({ createdAt: 1 });
+    expect(tokens).toHaveLength(3);
+    expect(tokens.every((token) => token.tokenHash && !token.token)).toBe(true);
     expect(EmailService.sendSupplierManagementEmail).toHaveBeenCalledTimes(3);
   });
 

--- a/backend-api/tests/unit/MagicLinkTokenIndexService.test.js
+++ b/backend-api/tests/unit/MagicLinkTokenIndexService.test.js
@@ -1,0 +1,42 @@
+jest.mock("../../models/MagicLinkToken");
+
+const MagicLinkToken = require("../../models/MagicLinkToken");
+const {
+  ensureMagicLinkTokenIndexCompatibility,
+} = require("../../services/MagicLinkTokenIndexService");
+
+describe("ensureMagicLinkTokenIndexCompatibility", () => {
+  beforeEach(() => {
+    MagicLinkToken.collection = {
+      indexes: jest.fn(),
+      dropIndex: jest.fn(),
+      createIndex: jest.fn(),
+    };
+  });
+
+  it("replaces the legacy non-sparse token index without removing uniqueness", async () => {
+    MagicLinkToken.collection.indexes.mockResolvedValue([
+      { name: "_id_", key: { _id: 1 } },
+      { name: "token_1", key: { token: 1 }, unique: true },
+    ]);
+
+    await expect(ensureMagicLinkTokenIndexCompatibility()).resolves.toBe(true);
+
+    expect(MagicLinkToken.collection.dropIndex).toHaveBeenCalledWith("token_1");
+    expect(MagicLinkToken.collection.createIndex).toHaveBeenCalledWith(
+      { token: 1 },
+      { name: "token_1", unique: true, sparse: true }
+    );
+  });
+
+  it("leaves the current sparse token index unchanged", async () => {
+    MagicLinkToken.collection.indexes.mockResolvedValue([
+      { name: "token_1", key: { token: 1 }, unique: true, sparse: true },
+    ]);
+
+    await expect(ensureMagicLinkTokenIndexCompatibility()).resolves.toBe(false);
+
+    expect(MagicLinkToken.collection.dropIndex).not.toHaveBeenCalled();
+    expect(MagicLinkToken.collection.createIndex).not.toHaveBeenCalled();
+  });
+});

--- a/backend-api/tests/unit/MagicLinkTokenIndexService.test.js
+++ b/backend-api/tests/unit/MagicLinkTokenIndexService.test.js
@@ -39,4 +39,16 @@ describe("ensureMagicLinkTokenIndexCompatibility", () => {
     expect(MagicLinkToken.collection.dropIndex).not.toHaveBeenCalled();
     expect(MagicLinkToken.collection.createIndex).not.toHaveBeenCalled();
   });
+
+  it("skips migration when the collection has not been created yet", async () => {
+    MagicLinkToken.collection.indexes.mockRejectedValue({
+      code: 26,
+      codeName: "NamespaceNotFound",
+    });
+
+    await expect(ensureMagicLinkTokenIndexCompatibility()).resolves.toBe(false);
+
+    expect(MagicLinkToken.collection.dropIndex).not.toHaveBeenCalled();
+    expect(MagicLinkToken.collection.createIndex).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Fixes #329

## Root cause
Legacy MongoDB deployments retained a non-sparse unique `token_1` index after magic links moved to hashed-only tokens. The first hashed token occupied the index's `null` value, globally blocking every later magic-link insert with a duplicate-key error.

## Changes made
- Repair the legacy index at API startup by recreating `token_1` as sparse and unique.
- Keep hashed token storage and atomic single-use consumption unchanged.
- Add coverage for consecutive requests for Supplier A, Supplier B, then Supplier A again.

## Tests performed
- `npm test` (backend): 16 suites, 154 tests passed.
- `npm run lint` and `npm run build` (frontend): passed; pre-existing warnings remain.

## Manual QA performed
- Requested management links sequentially for Supplier A, Supplier B, and Supplier A; each returned success, created a distinct hashed token, and dispatched an email.

## Migration/configuration impact
- No manual migration or configuration is required. On the next API startup, the existing `token_1` index is recreated as `{ unique: true, sparse: true }` when needed.

## Known risks
- The index rebuild is a brief startup-time database operation. It preserves the legacy token uniqueness constraint.
- #328 has the same root cause and carries the same safe migration on its independent QA-based branch; after either PR merges, rebase the remaining PR before merging to avoid duplicate migration code.