### PR TITLE
fix(supplier): restore supplier creation

### DIFF
--- a/backend-api/index.js
+++ b/backend-api/index.js
@@ -3,6 +3,9 @@ const cookieParser = require("cookie-parser");
 const cors = require("cors");
 const mongoose = require("mongoose");
 const dotenv = require("dotenv");
+const {
+  ensureMagicLinkTokenIndexCompatibility,
+} = require("./services/MagicLinkTokenIndexService");
 
 dotenv.config();
 const app = express();
@@ -165,6 +168,7 @@ async function connectMongo() {
   if (!process.env.MONGO_URI) return;
 
   await mongoose.connect(process.env.MONGO_URI);
+  await ensureMagicLinkTokenIndexCompatibility();
 
   if (!isTestOrCI) console.log("✅ Connecté à MongoDB");
 }

--- a/backend-api/services/MagicLinkTokenIndexService.js
+++ b/backend-api/services/MagicLinkTokenIndexService.js
@@ -13,7 +13,17 @@ const MagicLinkToken = require("../models/MagicLinkToken");
  */
 async function ensureMagicLinkTokenIndexCompatibility() {
   const collection = MagicLinkToken.collection;
-  const indexes = await collection.indexes();
+  let indexes;
+  try {
+    indexes = await collection.indexes();
+  } catch (err) {
+    // A fresh database has no collection yet. Mongoose creates its declared
+    // sparse indexes when the collection is first used.
+    if (err && (err.code === 26 || err.codeName === "NamespaceNotFound")) {
+      return false;
+    }
+    throw err;
+  }
   const tokenIndex = indexes.find(
     (index) =>
       index &&

--- a/backend-api/services/MagicLinkTokenIndexService.js
+++ b/backend-api/services/MagicLinkTokenIndexService.js
@@ -1,0 +1,42 @@
+const MagicLinkToken = require("../models/MagicLinkToken");
+
+/**
+ * Migrates the legacy non-sparse unique `token_1` index in place.
+ *
+ * Before token hashing was introduced, every token persisted a plaintext
+ * `token` value. Hashed tokens deliberately omit that field. A legacy
+ * non-sparse unique index therefore accepts one omitted value and rejects all
+ * later tokens with a duplicate-key error. Keeping the index sparse preserves
+ * uniqueness for legacy plaintext tokens while allowing hashed-only tokens.
+ *
+ * @returns {Promise<boolean>} Whether a legacy index was migrated.
+ */
+async function ensureMagicLinkTokenIndexCompatibility() {
+  const collection = MagicLinkToken.collection;
+  const indexes = await collection.indexes();
+  const tokenIndex = indexes.find(
+    (index) =>
+      index &&
+      index.name === "token_1" &&
+      index.key &&
+      index.key.token === 1
+  );
+
+  if (!tokenIndex || tokenIndex.sparse) {
+    return false;
+  }
+
+  await collection.dropIndex(tokenIndex.name);
+  await collection.createIndex(
+    { token: 1 },
+    {
+      name: tokenIndex.name,
+      unique: true,
+      sparse: true,
+    }
+  );
+
+  return true;
+}
+
+module.exports = { ensureMagicLinkTokenIndexCompatibility };

--- a/backend-api/tests/integration/supplierManagementAccess.test.js
+++ b/backend-api/tests/integration/supplierManagementAccess.test.js
@@ -28,7 +28,32 @@ describe("POST /api/suppliers/:id/management-link", () => {
     if (supplierRoutes.managementLinkRateLimit?.reset) {
       supplierRoutes.managementLinkRateLimit.reset();
     }
+    EmailService.sendSupplierActivationEmail.mockResolvedValue(true);
     EmailService.sendSupplierManagementEmail.mockResolvedValue(true);
+  });
+
+  it("creates a supplier and persists its activation token", async () => {
+    const res = await request(app).post("/api/suppliers").send({
+      name: "New Supplier",
+      categories: ["construction_materials"],
+      country: "CM",
+      accountEmail: "new-supplier@example.com",
+      phone: "0612345678",
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.body.accountEmail).toBe("new-supplier@example.com");
+    expect(res.body.status).toBe("Invited");
+    expect(res.body.isVisible).toBe(false);
+    expect(EmailService.sendSupplierActivationEmail).toHaveBeenCalledTimes(1);
+
+    const tokens = await MagicLinkToken.find({
+      supplierId: res.body._id,
+      purpose: "SUPPLIER_ACTIVATION",
+    });
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].tokenHash).toBeTruthy();
+    expect(tokens[0].token).toBeFalsy();
   });
 
   it("returns a generic confirmation and sends email when contact email matches", async () => {

--- a/backend-api/tests/unit/MagicLinkTokenIndexService.test.js
+++ b/backend-api/tests/unit/MagicLinkTokenIndexService.test.js
@@ -1,0 +1,42 @@
+jest.mock("../../models/MagicLinkToken");
+
+const MagicLinkToken = require("../../models/MagicLinkToken");
+const {
+  ensureMagicLinkTokenIndexCompatibility,
+} = require("../../services/MagicLinkTokenIndexService");
+
+describe("ensureMagicLinkTokenIndexCompatibility", () => {
+  beforeEach(() => {
+    MagicLinkToken.collection = {
+      indexes: jest.fn(),
+      dropIndex: jest.fn(),
+      createIndex: jest.fn(),
+    };
+  });
+
+  it("replaces the legacy non-sparse token index without removing uniqueness", async () => {
+    MagicLinkToken.collection.indexes.mockResolvedValue([
+      { name: "_id_", key: { _id: 1 } },
+      { name: "token_1", key: { token: 1 }, unique: true },
+    ]);
+
+    await expect(ensureMagicLinkTokenIndexCompatibility()).resolves.toBe(true);
+
+    expect(MagicLinkToken.collection.dropIndex).toHaveBeenCalledWith("token_1");
+    expect(MagicLinkToken.collection.createIndex).toHaveBeenCalledWith(
+      { token: 1 },
+      { name: "token_1", unique: true, sparse: true }
+    );
+  });
+
+  it("leaves the current sparse token index unchanged", async () => {
+    MagicLinkToken.collection.indexes.mockResolvedValue([
+      { name: "token_1", key: { token: 1 }, unique: true, sparse: true },
+    ]);
+
+    await expect(ensureMagicLinkTokenIndexCompatibility()).resolves.toBe(false);
+
+    expect(MagicLinkToken.collection.dropIndex).not.toHaveBeenCalled();
+    expect(MagicLinkToken.collection.createIndex).not.toHaveBeenCalled();
+  });
+});

--- a/backend-api/tests/unit/MagicLinkTokenIndexService.test.js
+++ b/backend-api/tests/unit/MagicLinkTokenIndexService.test.js
@@ -39,4 +39,16 @@ describe("ensureMagicLinkTokenIndexCompatibility", () => {
     expect(MagicLinkToken.collection.dropIndex).not.toHaveBeenCalled();
     expect(MagicLinkToken.collection.createIndex).not.toHaveBeenCalled();
   });
+
+  it("skips migration when the collection has not been created yet", async () => {
+    MagicLinkToken.collection.indexes.mockRejectedValue({
+      code: 26,
+      codeName: "NamespaceNotFound",
+    });
+
+    await expect(ensureMagicLinkTokenIndexCompatibility()).resolves.toBe(false);
+
+    expect(MagicLinkToken.collection.dropIndex).not.toHaveBeenCalled();
+    expect(MagicLinkToken.collection.createIndex).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Fixes #328

## Root cause
Legacy MongoDB deployments retained a non-sparse unique `token_1` index after magic links moved to hashed-only tokens. The first hashed token occupied the index's `null` value, so later activation-token creation failed with a duplicate-key error and supplier creation rolled back.

## Changes made
- Repair the legacy index at API startup by recreating `token_1` as sparse and unique.
- Preserve uniqueness for legacy plaintext tokens and avoid storing new raw tokens.
- Add API coverage for supplier creation and index-migration coverage.

## Tests performed
- `npm test` (backend): 16 suites, 154 tests passed.
- `npm run lint` and `npm run build` (frontend): passed; pre-existing warnings remain.

## Manual QA performed
- Created a valid supplier through `POST /api/suppliers`; confirmed a 201 response, invited/hidden persistence, hashed activation token, and activation-email dispatch.

## Migration/configuration impact
- No manual migration or configuration is required. On the next API startup, the existing `token_1` index is recreated as `{ unique: true, sparse: true }` when needed.

## Known risks
- The index rebuild is a brief startup-time database operation. It preserves the legacy token uniqueness constraint.