### PR TITLE
fix(ui): limit supplier card categories with overflow (#332)

### DIFF
--- a/app/components/suppliers/SupplierCard.tsx
+++ b/app/components/suppliers/SupplierCard.tsx
@@ -7,6 +7,7 @@ import {
   formatSupplierCityCountry,
   optionalStringList,
   optionalText,
+  splitVisibleCategories,
 } from "@/app/lib/supplierDisplay";
 
 export type SupplierCardProps = {
@@ -34,6 +35,8 @@ export default function SupplierCard({
 
   const displayName = optionalText(name) ?? "";
   const safeCategories = optionalStringList(categories);
+  const { visible: visibleCategories, hiddenCount } =
+    splitVisibleCategories(safeCategories);
   const safeResources = optionalStringList(resources);
   const location = formatSupplierCityCountry(city, country);
   const href = supplierProfilePath(id);
@@ -54,7 +57,7 @@ export default function SupplierCard({
           className="mb-3 flex flex-wrap gap-2"
           data-testid="supplier-card-categories"
         >
-          {safeCategories.map((category) => {
+          {visibleCategories.map((category) => {
             const labelKey = `suppliers.categoryOptions.${category}`;
             const label = t(labelKey);
             const display =
@@ -68,6 +71,14 @@ export default function SupplierCard({
               </span>
             );
           })}
+          {hiddenCount > 0 && (
+            <span
+              className="inline-flex rounded-full bg-secondary px-3 py-1 text-xs font-medium text-muted-foreground"
+              data-testid="supplier-card-more-categories"
+            >
+              {t("suppliers.cardMoreCategories", { count: hiddenCount })}
+            </span>
+          )}
         </div>
       )}
 

--- a/app/fournisseurs/[id]/page.tsx
+++ b/app/fournisseurs/[id]/page.tsx
@@ -17,8 +17,6 @@ import ContactSupplier from "@/app/components/suppliers/ContactSupplier";
 import SupplierRetrievalError from "@/app/components/suppliers/SupplierRetrievalError";
 import RequestManagementAccess from "@/app/components/suppliers/RequestManagementAccess";
 
-const MAX_VISIBLE_TAGS = 4;
-
 function categoryLabel(
   category: string,
   t: (key: string) => string
@@ -131,12 +129,11 @@ export default function SupplierProfilePage() {
   const categories = optionalStringList(supplier.categories);
   const primaryCategory = categories[0];
   const resourceTags = optionalStringList(supplier.resources);
+  // Detail page shows the complete category list (no truncation).
   const secondaryTags = [
     ...categories.slice(1).map((c) => categoryLabel(c, t)),
     ...resourceTags,
   ];
-  const visibleTags = secondaryTags.slice(0, MAX_VISIBLE_TAGS);
-  const overflowCount = Math.max(0, secondaryTags.length - visibleTags.length);
 
   return (
     <div className="wrap py-10 md:py-12" data-testid="supplier-profile-page">
@@ -169,13 +166,13 @@ export default function SupplierProfilePage() {
             {displayName}
           </h1>
 
-          {(visibleTags.length > 0 || overflowCount > 0) && (
+          {secondaryTags.length > 0 && (
             <div
               className="mt-4 flex flex-wrap gap-2"
               data-testid="supplier-profile-categories"
               aria-label={t("suppliers.categoriesAria")}
             >
-              {visibleTags.map((tag) => (
+              {secondaryTags.map((tag) => (
                 <span
                   key={tag}
                   className="inline-flex rounded-full bg-secondary px-2.5 py-1 text-xs font-medium text-foreground"
@@ -183,11 +180,6 @@ export default function SupplierProfilePage() {
                   {tag}
                 </span>
               ))}
-              {overflowCount > 0 && (
-                <span className="inline-flex rounded-full bg-secondary px-2.5 py-1 text-xs font-medium text-muted-foreground">
-                  +{overflowCount}
-                </span>
-              )}
             </div>
           )}
         </div>

--- a/app/lib/supplierDisplay.ts
+++ b/app/lib/supplierDisplay.ts
@@ -63,3 +63,24 @@ export function formatSupplierCityCountry(
   if (parts.length === 0) return undefined;
   return parts.join(", ");
 }
+
+/** Max category badges shown on Supplier Directory cards. */
+export const SUPPLIER_CARD_MAX_VISIBLE_CATEGORIES = 3;
+
+/**
+ * Limits category badges for compact card layout without altering stored data.
+ * Returns the first `maxVisible` categories and how many remain hidden.
+ */
+export function splitVisibleCategories(
+  categories: readonly string[],
+  maxVisible: number = SUPPLIER_CARD_MAX_VISIBLE_CATEGORIES
+): { visible: string[]; hiddenCount: number } {
+  const limit = Number.isFinite(maxVisible) && maxVisible > 0 ? maxVisible : 0;
+  if (categories.length <= limit) {
+    return { visible: [...categories], hiddenCount: 0 };
+  }
+  return {
+    visible: categories.slice(0, limit),
+    hiddenCount: categories.length - limit,
+  };
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -254,6 +254,7 @@
     "filterAll": "All",
     "clearFilters": "Clear filters",
     "cardProfileAria": "View {name} profile",
+    "cardMoreCategories": "+{count} more",
     "profileLoading": "Loading supplier profile...",
     "profileNotFound": "This supplier is not available.",
     "profileLoadError": "Unable to load this profile. Please try again later.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -254,6 +254,7 @@
     "filterAll": "Tous",
     "clearFilters": "Effacer les filtres",
     "cardProfileAria": "Voir le profil de {name}",
+    "cardMoreCategories": "+{count} autres",
     "profileLoading": "Chargement du profil fournisseur...",
     "profileNotFound": "Ce fournisseur n'est pas disponible.",
     "profileLoadError": "Impossible de charger ce profil. Veuillez réessayer plus tard.",

--- a/tests/ui/supplier-directory.spec.ts
+++ b/tests/ui/supplier-directory.spec.ts
@@ -19,6 +19,61 @@ const MULTI_CATEGORY_SUPPLIER = {
   phone: "+237600000002",
 };
 
+const MANY_CATEGORIES_SUPPLIER = {
+  id: "65a1b2c3d4e5f67890123499",
+  name: "MultiCat Supply",
+  categories: [
+    "import_wholesale_distribution",
+    "packaging_containers",
+    "transport_logistics",
+    "construction_materials",
+    "wood_lumber",
+    "metal_steel",
+    "electrical_supplies",
+    "plumbing_supplies",
+    "paints_finishes",
+    "hardware_fasteners",
+    "hand_tools",
+    "power_tools",
+    "industrial_machinery",
+    "safety_equipment",
+    "textiles_fabrics",
+    "leather_accessories",
+    "art_craft_materials",
+    "agro_raw_materials",
+  ],
+  country: "Cameroun",
+  city: "Douala",
+  phone: "+237600000099",
+};
+
+const EXACTLY_THREE_CATEGORIES_SUPPLIER = {
+  id: "65a1b2c3d4e5f67890123488",
+  name: "ThreeCat Supply",
+  categories: [
+    "construction_materials",
+    "wood_lumber",
+    "metal_steel",
+  ],
+  country: "Cameroun",
+  city: "Bafoussam",
+  phone: "+237600000088",
+};
+
+const FOUR_CATEGORIES_SUPPLIER = {
+  id: "65a1b2c3d4e5f67890123477",
+  name: "FourCat Supply",
+  categories: [
+    "construction_materials",
+    "wood_lumber",
+    "metal_steel",
+    "electrical_supplies",
+  ],
+  country: "Cameroun",
+  city: "Garoua",
+  phone: "+237600000077",
+};
+
 const MINIMAL_SUPPLIER = {
   id: "65a1b2c3d4e5f678901234ef",
   name: "Minimal Supply",
@@ -161,6 +216,115 @@ test.describe("Supplier Directory", () => {
     const categories = page.getByTestId("supplier-card-categories");
     await expect(categories).toContainText("Matériaux de construction");
     await expect(categories).toContainText("Métal et acier");
+    await expect(page.getByTestId("supplier-card-more-categories")).toHaveCount(
+      0
+    );
+  });
+
+  test("shows at most 3 category badges plus a localized overflow count", async ({
+    page,
+  }) => {
+    await mockSuppliers(page, [
+      EXACTLY_THREE_CATEGORIES_SUPPLIER,
+      FOUR_CATEGORIES_SUPPLIER,
+      MANY_CATEGORIES_SUPPLIER,
+    ]);
+
+    await page.goto("/fournisseurs");
+
+    const threeCatCard = page.locator(
+      `[data-testid="supplier-card"][data-supplier-id="${EXACTLY_THREE_CATEGORIES_SUPPLIER.id}"]`
+    );
+    await expect(
+      threeCatCard.getByTestId("supplier-card-categories").locator("span")
+    ).toHaveCount(3);
+    await expect(
+      threeCatCard.getByTestId("supplier-card-more-categories")
+    ).toHaveCount(0);
+
+    const fourCatCard = page.locator(
+      `[data-testid="supplier-card"][data-supplier-id="${FOUR_CATEGORIES_SUPPLIER.id}"]`
+    );
+    await expect(
+      fourCatCard.getByTestId("supplier-card-categories").locator("span")
+    ).toHaveCount(4);
+    await expect(
+      fourCatCard.getByTestId("supplier-card-more-categories")
+    ).toHaveText("+1 autres");
+    await expect(fourCatCard).not.toContainText("Fournitures électriques");
+
+    const manyCatCard = page.locator(
+      `[data-testid="supplier-card"][data-supplier-id="${MANY_CATEGORIES_SUPPLIER.id}"]`
+    );
+    await expect(
+      manyCatCard.getByTestId("supplier-card-categories").locator("span")
+    ).toHaveCount(4);
+    await expect(
+      manyCatCard.getByTestId("supplier-card-more-categories")
+    ).toHaveText("+15 autres");
+    await expect(manyCatCard).toContainText("Import / distribution en gros");
+    await expect(manyCatCard).toContainText("Emballages et contenants");
+    await expect(manyCatCard).toContainText("Transport et logistique");
+    await expect(manyCatCard).not.toContainText("Matières premières agricoles");
+  });
+
+  test("renders English overflow indicator for many categories", async ({
+    page,
+  }) => {
+    await page.addInitScript(() => {
+      window.localStorage.setItem("sawaka-locale", "en");
+    });
+    await mockSuppliers(page, [MANY_CATEGORIES_SUPPLIER]);
+
+    await page.goto("/fournisseurs");
+
+    await expect(page.getByTestId("supplier-card-more-categories")).toHaveText(
+      "+15 more"
+    );
+  });
+
+  test("filters by a category hidden behind the card overflow indicator", async ({
+    page,
+  }) => {
+    const directory = [...ALL_SUPPLIERS, MANY_CATEGORIES_SUPPLIER];
+    await page.route("**/api/suppliers**", async (route: Route) => {
+      const request = route.request();
+      const url = request.url();
+      if (!isSupplierListRequest(url, request.method())) {
+        await route.continue();
+        return;
+      }
+
+      const parsed = new URL(url);
+      const search = (parsed.searchParams.get("search") ?? "").trim().toLowerCase();
+      const category = (parsed.searchParams.get("category") ?? "").trim();
+
+      let results = [...directory];
+      if (search) {
+        results = results.filter((s) => s.name.toLowerCase().includes(search));
+      }
+      if (category) {
+        results = results.filter((s) => s.categories.includes(category));
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(results),
+      });
+    });
+
+    await page.goto("/fournisseurs");
+    await page.getByTestId("supplier-filter-agro_raw_materials").click();
+
+    await expect(page).toHaveURL(/category=agro_raw_materials/);
+    await expect(page.getByTestId("supplier-card")).toHaveCount(1);
+    await expect(page.getByTestId("supplier-card-name")).toHaveText(
+      "MultiCat Supply"
+    );
+    await expect(page.getByTestId("supplier-card-more-categories")).toHaveText(
+      "+15 autres"
+    );
   });
 
   test("card is an accessible link to the supplier profile URL", async ({

--- a/tests/ui/supplier-profile.spec.ts
+++ b/tests/ui/supplier-profile.spec.ts
@@ -133,6 +133,50 @@ test.describe("Supplier Profile page", () => {
     expect(html).not.toContain("mailto:secret@private.cm");
   });
 
+  test("displays the complete category list on the detail page", async ({
+    page,
+  }) => {
+    const manyCategories = [
+      "import_wholesale_distribution",
+      "packaging_containers",
+      "transport_logistics",
+      "construction_materials",
+      "wood_lumber",
+      "metal_steel",
+      "electrical_supplies",
+      "plumbing_supplies",
+      "paints_finishes",
+      "hardware_fasteners",
+      "hand_tools",
+      "power_tools",
+      "industrial_machinery",
+      "safety_equipment",
+      "textiles_fabrics",
+      "leather_accessories",
+      "art_craft_materials",
+      "agro_raw_materials",
+    ];
+
+    await mockProfile(page, {
+      body: {
+        categories: manyCategories,
+        resources: [],
+      },
+    });
+
+    await page.goto(`/fournisseurs/${SUPPLIER_ID}`);
+
+    await expect(
+      page.getByTestId("supplier-profile-primary-category")
+    ).toContainText("Import / distribution en gros");
+
+    const tags = page.getByTestId("supplier-profile-categories");
+    await expect(tags).toContainText("Emballages et contenants");
+    await expect(tags).toContainText("Transport et logistique");
+    await expect(tags).toContainText("Matières premières agricoles");
+    await expect(tags).not.toContainText("+");
+  });
+
   test("hides missing optional fields", async ({ page }) => {
     await mockProfile(page, {
       body: {


### PR DESCRIPTION
## Summary
Fixes #332

### Root cause
Supplier Directory cards rendered every category badge for a supplier. When a supplier had many categories, badges consumed vertical space and pushed the name/location down, breaking visual consistency across cards.

### Changes made
- Cap directory card category badges at 3 and show a localized overflow indicator (`+X autres` / `+X more`) for the remaining count.
- Keep stored supplier category data unchanged; truncation is display-only on the card.
- Ensure the Supplier Detail page continues to show the complete category list (no truncation).
- Add FR/EN translation keys for the overflow indicator.
- Extend Playwright coverage for 0/1/3/4/many categories, FR/EN overflow text, filtering by a hidden category, and full detail-page category display.

### Tests performed
- `npm run lint`
- `npm run build` (includes typecheck)
- `npx playwright test tests/ui/supplier-directory.spec.ts tests/ui/supplier-profile.spec.ts tests/ui/supplier-optional-fields.spec.ts` (33 passed)

### Manual QA instructions
1. Open the Supplier Directory on desktop, tablet, and mobile.
2. Find or create a supplier with many categories (4+).
3. Verify the card shows at most 3 category badges plus `+X autres` (FR) / `+X more` (EN).
4. Switch locale FR ↔ EN and confirm the indicator text.
5. Open the supplier detail page and confirm all categories are listed.
6. Filter/search by a category that is not among the first 3 visible badges and confirm the supplier still matches.
7. Compare cards with 0, 1, 3, and many categories for consistent name/location layout.

### Risks / regression considerations
- Display-only change; no API, data model, or filtering logic changes.
- Detail page previously truncated mixed category/resource tags after 4; it now shows the complete list, which may make very long lists taller on the profile page.
- Do not merge until Vercel Preview / CI are green.