### PR TITLE
fix(api): allow partial Edit Supplier PATCH without revalidation (#333)

### DIFF
--- a/backend-api/services/SupplierService.js
+++ b/backend-api/services/SupplierService.js
@@ -213,7 +213,9 @@ function isValidOptionalUrl(value) {
 }
 
 /**
- * Validate and normalize editable supplier update payload.
+ * Validate and normalize editable supplier update payload (PATCH semantics).
+ * Only fields present in the payload are validated/updated; omitted required
+ * fields keep their current persisted values.
  * System fields (status, isVisible, ownerId, timestamps) are stripped.
  * @returns {{ updates: object, changedFields: string[], pendingContactEmail: string|null }}
  */
@@ -245,63 +247,85 @@ function parseEditableUpdate(data, currentSupplier) {
   /** @type {string|null} */
   let pendingContactEmail = null;
 
-  const name = typeof raw.name === "string" ? raw.name.trim() : "";
-  if (!name || name.length < 2) {
-    errors.name = !name
-      ? "name is required"
-      : "name must be at least 2 characters";
-  } else {
-    updates.name = name;
-    if (name !== (currentSupplier.name || "")) changedFields.push("name");
-  }
-
-  let categories = raw.categories;
-  if (!Array.isArray(categories) || categories.length === 0) {
-    errors.categories = "At least one category is required";
-  } else {
-    const normalized = [
-      ...new Set(
-        categories
-          .filter((c) => typeof c === "string")
-          .map((c) => c.trim())
-          .filter(Boolean)
-      ),
-    ];
-    if (
-      normalized.length === 0 ||
-      normalized.some((c) => !VALID_SUPPLIER_CATEGORIES.has(c))
-    ) {
-      errors.categories = "Invalid category";
+  if (raw.name !== undefined) {
+    if (typeof raw.name !== "string") {
+      errors.name = "name must be a string";
     } else {
-      updates.categories = normalized;
-      const prev = Array.isArray(currentSupplier.categories)
-        ? currentSupplier.categories
-        : [];
-      if (
-        normalized.length !== prev.length ||
-        normalized.some((c, i) => c !== prev[i])
-      ) {
-        changedFields.push("categories");
+      const name = raw.name.trim();
+      if (!name || name.length < 2) {
+        errors.name = !name
+          ? "name is required"
+          : "name must be at least 2 characters";
+      } else {
+        updates.name = name;
+        if (name !== (currentSupplier.name || "")) changedFields.push("name");
       }
     }
   }
 
-  const country = typeof raw.country === "string" ? raw.country.trim() : "";
-  if (!country) {
-    errors.country = "country is required";
-  } else {
-    updates.country = country;
-    if (country !== (currentSupplier.country || "")) changedFields.push("country");
+  if (raw.categories !== undefined) {
+    const categories = raw.categories;
+    if (!Array.isArray(categories) || categories.length === 0) {
+      errors.categories = "At least one category is required";
+    } else {
+      const normalized = [
+        ...new Set(
+          categories
+            .filter((c) => typeof c === "string")
+            .map((c) => c.trim())
+            .filter(Boolean)
+        ),
+      ];
+      if (
+        normalized.length === 0 ||
+        normalized.some((c) => !VALID_SUPPLIER_CATEGORIES.has(c))
+      ) {
+        errors.categories = "Invalid category";
+      } else {
+        updates.categories = normalized;
+        const prev = Array.isArray(currentSupplier.categories)
+          ? currentSupplier.categories
+          : [];
+        if (
+          normalized.length !== prev.length ||
+          normalized.some((c, i) => c !== prev[i])
+        ) {
+          changedFields.push("categories");
+        }
+      }
+    }
   }
 
-  const phone = typeof raw.phone === "string" ? raw.phone.trim() : "";
-  if (!phone) {
-    errors.phone = "phone is required";
-  } else if (phone.length < 6) {
-    errors.phone = "phone must be at least 6 characters";
-  } else {
-    updates.phone = phone;
-    if (phone !== (currentSupplier.phone || "")) changedFields.push("phone");
+  if (raw.country !== undefined) {
+    if (typeof raw.country !== "string") {
+      errors.country = "country must be a string";
+    } else {
+      const country = raw.country.trim();
+      if (!country) {
+        errors.country = "country is required";
+      } else {
+        updates.country = country;
+        if (country !== (currentSupplier.country || "")) {
+          changedFields.push("country");
+        }
+      }
+    }
+  }
+
+  if (raw.phone !== undefined) {
+    if (typeof raw.phone !== "string") {
+      errors.phone = "phone must be a string";
+    } else {
+      const phone = raw.phone.trim();
+      if (!phone) {
+        errors.phone = "phone is required";
+      } else if (phone.length < 6) {
+        errors.phone = "phone must be at least 6 characters";
+      } else {
+        updates.phone = phone;
+        if (phone !== (currentSupplier.phone || "")) changedFields.push("phone");
+      }
+    }
   }
 
   // Contact email change → pending verification (verified email stays active).

--- a/backend-api/tests/integration/supplierManagementUpdate.test.js
+++ b/backend-api/tests/integration/supplierManagementUpdate.test.js
@@ -146,6 +146,99 @@ describe("GET/PATCH /api/suppliers/management", () => {
     expect(res.body.errors).toBeDefined();
   });
 
+  it("accepts a partial PATCH that only changes an optional field", async () => {
+    const supplier = await createActiveSupplier({
+      accountEmail: "partial@example.com",
+      website: "https://before.example.com",
+      city: "Yaoundé",
+    });
+    const token = await sessionTokenFor(supplier._id);
+
+    const res = await request(app)
+      .patch("/api/suppliers/management")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ website: "https://after.example.com" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.supplier).toMatchObject({
+      name: "Editable Co",
+      categories: ["construction_materials"],
+      country: "CM",
+      city: "Yaoundé",
+      phone: "0612345678",
+      accountEmail: "partial@example.com",
+      website: "https://after.example.com",
+    });
+
+    const stored = await Supplier.findById(supplier._id).lean();
+    expect(stored.name).toBe("Editable Co");
+    expect(stored.categories).toEqual(["construction_materials"]);
+    expect(stored.country).toBe("CM");
+    expect(stored.phone).toBe("0612345678");
+    expect(stored.accountEmail).toBe("partial@example.com");
+    expect(stored.website).toBe("https://after.example.com");
+    expect(stored.city).toBe("Yaoundé");
+  });
+
+  it("accepts a partial PATCH that only changes phone", async () => {
+    const supplier = await createActiveSupplier({
+      accountEmail: "phone-only@example.com",
+    });
+    const token = await sessionTokenFor(supplier._id);
+
+    const res = await request(app)
+      .patch("/api/suppliers/management")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ phone: "0699887766" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.supplier.phone).toBe("0699887766");
+    expect(res.body.supplier.name).toBe("Editable Co");
+    expect(res.body.supplier.accountEmail).toBe("phone-only@example.com");
+
+    const stored = await Supplier.findById(supplier._id).lean();
+    expect(stored.phone).toBe("0699887766");
+    expect(stored.name).toBe("Editable Co");
+    expect(stored.categories).toEqual(["construction_materials"]);
+  });
+
+  it("accepts a partial PATCH that only changes categories", async () => {
+    const supplier = await createActiveSupplier({
+      accountEmail: "cats-only@example.com",
+    });
+    const token = await sessionTokenFor(supplier._id);
+
+    const res = await request(app)
+      .patch("/api/suppliers/management")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ categories: ["wood_lumber", "metal_steel"] });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body.supplier.categories).toEqual([
+      "wood_lumber",
+      "metal_steel",
+    ]);
+    expect(res.body.supplier.phone).toBe("0612345678");
+  });
+
+  it("rejects clearing a required field in a partial PATCH", async () => {
+    const supplier = await createActiveSupplier({
+      accountEmail: "clear-required@example.com",
+    });
+    const token = await sessionTokenFor(supplier._id);
+
+    const res = await request(app)
+      .patch("/api/suppliers/management")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "" });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.body.errors).toHaveProperty("name");
+
+    const stored = await Supplier.findById(supplier._id).lean();
+    expect(stored.name).toBe("Editable Co");
+  });
+
   it("stores a changed contact email as pending without replacing the verified email", async () => {
     const supplier = await createActiveSupplier({
       accountEmail: "keep@example.com",

--- a/backend-api/tests/unit/SupplierService.test.js
+++ b/backend-api/tests/unit/SupplierService.test.js
@@ -917,4 +917,92 @@ describe("SupplierService", () => {
       expect(MagicLinkService.consumeToken).not.toHaveBeenCalled();
     });
   });
+
+  describe("parseEditableUpdate", () => {
+    const current = {
+      name: "Editable Co",
+      categories: ["construction_materials"],
+      country: "CM",
+      city: "Yaoundé",
+      accountEmail: "owner@example.com",
+      phone: "0612345678",
+      publicEmail: "public@example.com",
+      website: "https://before.example.com",
+    };
+
+    it("accepts a partial payload with only an optional field", () => {
+      const result = SupplierService.parseEditableUpdate(
+        { website: "https://after.example.com" },
+        current
+      );
+
+      expect(result.updates).toEqual({
+        website: "https://after.example.com",
+      });
+      expect(result.changedFields).toEqual(["website"]);
+      expect(result.pendingContactEmail).toBeNull();
+    });
+
+    it("accepts a partial payload with only phone", () => {
+      const result = SupplierService.parseEditableUpdate(
+        { phone: "0699887766" },
+        current
+      );
+
+      expect(result.updates).toEqual({ phone: "0699887766" });
+      expect(result.changedFields).toEqual(["phone"]);
+    });
+
+    it("accepts a partial payload with only categories", () => {
+      const result = SupplierService.parseEditableUpdate(
+        { categories: ["wood_lumber"] },
+        current
+      );
+
+      expect(result.updates).toEqual({ categories: ["wood_lumber"] });
+      expect(result.changedFields).toEqual(["categories"]);
+    });
+
+    it("rejects clearing a required field when it is present in the payload", () => {
+      expect(() =>
+        SupplierService.parseEditableUpdate({ name: "" }, current)
+      ).toThrow("Validation failed");
+
+      try {
+        SupplierService.parseEditableUpdate({ name: "" }, current);
+      } catch (err) {
+        expect(err.code).toBe("VALIDATION_ERROR");
+        expect(err.errors).toMatchObject({ name: "name is required" });
+      }
+    });
+
+    it("rejects an empty categories array when present in the payload", () => {
+      expect(() =>
+        SupplierService.parseEditableUpdate({ categories: [] }, current)
+      ).toThrow("Validation failed");
+
+      try {
+        SupplierService.parseEditableUpdate({ categories: [] }, current);
+      } catch (err) {
+        expect(err.code).toBe("VALIDATION_ERROR");
+        expect(err.errors).toMatchObject({
+          categories: "At least one category is required",
+        });
+      }
+    });
+
+    it("does not overwrite omitted required fields", () => {
+      const result = SupplierService.parseEditableUpdate(
+        { city: "Douala" },
+        current
+      );
+
+      expect(result.updates).toEqual({ city: "Douala" });
+      expect(result.updates).not.toHaveProperty("name");
+      expect(result.updates).not.toHaveProperty("categories");
+      expect(result.updates).not.toHaveProperty("country");
+      expect(result.updates).not.toHaveProperty("phone");
+      expect(result.updates).not.toHaveProperty("accountEmail");
+    });
+  });
 });

--- a/tests/ui/supplier-manage-form.spec.ts
+++ b/tests/ui/supplier-manage-form.spec.ts
@@ -199,6 +199,191 @@ test.describe("Supplier management edit form", () => {
     await expect(page.getByTestId("manage-supplier-save")).toBeDisabled();
   });
 
+  test("saving only an unrelated field does not require re-entering required fields", async ({
+    page,
+  }) => {
+    let patchBody: Record<string, unknown> | null = null;
+    await page.route("**/api/suppliers/**", async (route: Route) => {
+      const request = route.request();
+      const url = request.url();
+      const method = request.method();
+
+      if (url.includes("/api/suppliers/management") && method === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(EDITABLE_SUPPLIER),
+        });
+        return;
+      }
+
+      if (url.includes("/api/suppliers/management") && method === "PATCH") {
+        patchBody = request.postDataJSON() as Record<string, unknown>;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            supplier: { ...EDITABLE_SUPPLIER, ...patchBody },
+          }),
+        });
+        return;
+      }
+
+      if (method === "GET" && url.includes(`/api/suppliers/${SUPPLIER_ID}`)) {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(EDITABLE_SUPPLIER),
+        });
+        return;
+      }
+
+      await route.continue();
+    });
+
+    await page.goto("/supplier/manage");
+    await expect(page.getByTestId("manage-supplier-form")).toBeVisible({
+      timeout: 10000,
+    });
+
+    await page
+      .getByTestId("manage-supplier-input-website")
+      .fill("https://updated.boisplus.cm");
+    await page.getByTestId("manage-supplier-save").click();
+
+    await expect(page.getByTestId("manage-supplier-success")).toBeVisible();
+    await expect(page.getByTestId("manage-supplier-error-name")).toHaveCount(0);
+    await expect(page.getByTestId("manage-supplier-error-country")).toHaveCount(
+      0
+    );
+    await expect(page.getByTestId("manage-supplier-error-phone")).toHaveCount(0);
+    await expect(
+      page.getByTestId("manage-supplier-error-account-email")
+    ).toHaveCount(0);
+    await expect(
+      page.getByTestId("manage-supplier-error-categories")
+    ).toHaveCount(0);
+
+    expect(patchBody).toEqual({
+      website: "https://updated.boisplus.cm",
+    });
+
+    await expect(page.getByTestId("manage-supplier-input-name")).toHaveValue(
+      EDITABLE_SUPPLIER.name
+    );
+    await expect(page.getByTestId("manage-supplier-input-country")).toHaveValue(
+      EDITABLE_SUPPLIER.country
+    );
+    await expect(page.getByTestId("manage-supplier-input-phone")).toHaveValue(
+      EDITABLE_SUPPLIER.phone
+    );
+    await expect(
+      page.getByTestId("manage-supplier-input-account-email")
+    ).toHaveValue(EDITABLE_SUPPLIER.accountEmail);
+  });
+
+  test("saving only a phone change keeps other required values", async ({
+    page,
+  }) => {
+    let patchBody: Record<string, unknown> | null = null;
+    await page.route("**/api/suppliers/**", async (route: Route) => {
+      const request = route.request();
+      const url = request.url();
+      const method = request.method();
+
+      if (url.includes("/api/suppliers/management") && method === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(EDITABLE_SUPPLIER),
+        });
+        return;
+      }
+
+      if (url.includes("/api/suppliers/management") && method === "PATCH") {
+        patchBody = request.postDataJSON() as Record<string, unknown>;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            supplier: { ...EDITABLE_SUPPLIER, ...patchBody },
+          }),
+        });
+        return;
+      }
+
+      await route.continue();
+    });
+
+    await page.goto("/supplier/manage");
+    await expect(page.getByTestId("manage-supplier-form")).toBeVisible({
+      timeout: 10000,
+    });
+
+    await page
+      .getByTestId("manage-supplier-input-phone")
+      .fill("+237 600 11 22 33");
+    await page.getByTestId("manage-supplier-save").click();
+
+    await expect(page.getByTestId("manage-supplier-success")).toBeVisible();
+    expect(patchBody).toEqual({ phone: "+237 600 11 22 33" });
+    await expect(page.getByTestId("manage-supplier-input-name")).toHaveValue(
+      EDITABLE_SUPPLIER.name
+    );
+  });
+
+  test("saving only a category change keeps other required values", async ({
+    page,
+  }) => {
+    let patchBody: Record<string, unknown> | null = null;
+    await page.route("**/api/suppliers/**", async (route: Route) => {
+      const request = route.request();
+      const url = request.url();
+      const method = request.method();
+
+      if (url.includes("/api/suppliers/management") && method === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(EDITABLE_SUPPLIER),
+        });
+        return;
+      }
+
+      if (url.includes("/api/suppliers/management") && method === "PATCH") {
+        patchBody = request.postDataJSON() as Record<string, unknown>;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            supplier: {
+              ...EDITABLE_SUPPLIER,
+              categories: patchBody.categories as string[],
+            },
+          }),
+        });
+        return;
+      }
+
+      await route.continue();
+    });
+
+    await page.goto("/supplier/manage");
+    await expect(page.getByTestId("manage-supplier-form")).toBeVisible({
+      timeout: 10000,
+    });
+
+    await page
+      .getByTestId("manage-supplier-category-construction_materials")
+      .click();
+    await page.getByTestId("manage-supplier-save").click();
+
+    await expect(page.getByTestId("manage-supplier-success")).toBeVisible();
+    expect(patchBody).toEqual({
+      categories: ["wood_lumber", "construction_materials"],
+    });
+  });
+
   test("invalid values block saving", async ({ page }) => {
     await mockManagementApis(page);
     await page.goto("/supplier/manage");


### PR DESCRIPTION
## Summary
Fixes #333

### Root cause
`parseEditableUpdate` validated required fields (`name`, `categories`, `country`, `phone`) even when they were **absent** from a PATCH payload. The Edit Supplier form correctly sends only changed fields, so saving a single unrelated change caused the backend to treat omitted required fields as empty and return validation errors.

### Changes made
- Align backend update validation with PATCH semantics: validate required fields only when they are present in the payload.
- Preserve persisted values for omitted fields (no overwrite with empty/undefined).
- Keep full required-field enforcement when a required field is deliberately cleared or invalid.
- Add unit, integration, and Playwright regression coverage for partial updates (website/phone/category) and cleared required fields.

### Tests performed
- `npm test` in `backend-api` (full suite previously green; targeted update suites: 67 passed)
- `npm run lint`
- `npm run build`
- `npx playwright test tests/ui/supplier-manage-form.spec.ts` (15 passed)

### Manual QA instructions
1. Open an existing supplier via Edit Supplier (valid magic-link session).
2. Confirm all required fields already have values.
3. Change only website (or phone, or one category) and click **Save Changes**.
4. Confirm save succeeds with no required-field errors on untouched fields.
5. Reload/reopen Edit Supplier and confirm persisted values are intact.
6. Deliberately clear a required field (e.g. name) and confirm validation still blocks save.
7. Confirm Contact Email remains required/private and Public Email remains optional.

### Risks / regression considerations
- Backend-only validation semantics change for PATCH `/api/suppliers/management`.
- Clients that previously relied on sending a full PUT-like body remain compatible.
- Requires backend deployment for the fix to take effect in environments that serve the API separately from the Vercel frontend.
- Do not merge until CI is green.